### PR TITLE
2.1: Note about automatic populating of the self_update parameter in the Kerner Options

### DIFF
--- a/xml/manager_reference_virtualization.xml
+++ b/xml/manager_reference_virtualization.xml
@@ -217,8 +217,10 @@
          <para>
           Options passed to the kernel when booting for the installation.
           There is no need to specify the <option>install=</option>
-          parameter since it will automatically be added. This field is
-          optional.
+          parameter since it will automatically be added. Moreover, the
+          parameters <option>self_update=0 pt.options=self_update</option> are
+          added automatically to prevent AutoYaST from updating itself during
+          the system installation. This field is optional.
          </para>
         </listitem>
        </varlistentry>


### PR DESCRIPTION
This is for 2.1 - is this the correct branch?

It should go to doc for 3.0 as well, but it seems the file with corresponding contents doesn't exist (was looking in the develop branch).
