### PR TITLE
Suggest better command for minion onboarding

### DIFF
--- a/xml/bp_chap_salt_minion_onboarding_scaleability.xml
+++ b/xml/bp_chap_salt_minion_onboarding_scaleability.xml
@@ -20,7 +20,7 @@
             potentially exhausting resources. It is recommended to limit the acceptance key rate
             pro-grammatically. A safe starting point would be to on-board a minion every 15 seconds,
             which can be implemented via the following command:</para>
-        <screen>for i in `seq 1 1000`; do salt-key -y -a minion$i; sleep 15; done</screen>
+        <screen>for k in $(salt-key -l un|grep -v Unaccepted); do salt-key -y -a $k; sleep 15; done </screen>
     </sect1>
 
     <sect1>


### PR DESCRIPTION
From the mailing list:

> On 11/11/2016 15:45, Simon Crute wrote:
> Thanks,
> Although I think the command they suggest will only work if you have numbered minions.
> This might be a better one.
> 
> for k in $(salt-key -l un|grep -v Unaccepted); do salt-key -y -a $k; sleep 15; done
