### PR TITLE
Remove reference to a link that was removed

### DIFF
--- a/xml/s1-sm-systems.xml
+++ b/xml/s1-sm-systems.xml
@@ -95,8 +95,7 @@
      Some icons are linked to related tasks. For instance, the standard
      Updates icon is linked to the <guimenu>Upgrade</guimenu> subtab of the
      packages list, while the Critical Updates icon links directly to the
-     <guimenu>Update Confirmation</guimenu> page. The Not Checking In icon
-     is linked to instructions for resolving the issue.
+     <guimenu>Update Confirmation</guimenu> page.
     </para>
     <itemizedlist>
      <listitem>


### PR DESCRIPTION
The link was removed since 2.1, so it is safe to remove the sentence now.

See https://bugzilla.suse.com/show_bug.cgi?id=1035717

PS. I am not sure whether the `master` branch this PR is pointing at is correct! Feel free to cherry-pick in other branches if necessary.