### PR TITLE
Add some documentation for enabling Salt Virtualization Hosts

### DIFF
--- a/adoc/advanced_topics_virtualization.adoc
+++ b/adoc/advanced_topics_virtualization.adoc
@@ -414,25 +414,41 @@ guests, which are managed by [library]``libvirt``
 ** Download the bootstrap script from `susemanager.example.com/pub/bootstrap/bootstrap.sh` to the {vmhost} .
 ** Edit the bootstrap script according to your needs. The minimal requirement is to include the activation key for the {vmhost} (see <<sec.virtualzation.autoinstall.req-mgr.keys>> for details). We strongly recommend to also include one or more GPG keys (for example, your organization key and package signing keys).
 ** Execute the bootstrap script to register the {vmhost} .
-. {empty}
 +
+
+
+[[sec.virtualization.autoinstall.req_vmhost.salt]]
+===== {vmhost} setup on Salt clients.
+
+
+If the {vmhost} is registered as a Salt minion, a final configuration step is needed in order to gather all the guest VMs defined on the {vmhost}:
+
+
+. From the menu:System Details[Properties] page, enable the menu:Add-on System Type[] ``Virtualization Host`` and confirm by selecting btn:[Update Properties].
+. Schedule a Hardware Refresh. From the system's details page select menu:System Details[Hardware] and click on btn:[Schedule Hardware Refresh].
+
+
+[[sec.virtualization.autoinstall.req_vmhost.traditional]]
+===== {vmhost} setup on Traditional clients.
+
+
 Once the registration process is finished and all packages have been installed, enable the [daemon]``osad``
 (Open Source Architecture Daemon). On a {sls}
 system this can be achieved by running the following commands as user {rootuser}
 :
-+
+
 
 ----
 systemctl stop rhnsd
 systemctl disable rhnsd
 ----
-+
+
 
 ----
 systemctl enable osad
 systemctl start osad
 ----
-+
+
 .[daemon]``osad``Together with [daemon]``rhnsd``
 IMPORTANT: The [daemon]``rhnsd``
  daemon checks for scheduled actions every four hours, so it can take up to four hours before a scheduled action is carried out.
@@ -448,7 +464,6 @@ The [daemon]``osad``
  and commands are instantly executed.
 Alternatively you may schedule actions to be carried out at a fixed time in the future (whereas with [daemon]``rhnsd``
  you can only schedule for a time in the future plus up to four hours).
-+
 
 
 

--- a/adoc/advanced_topics_virtualization.adoc
+++ b/adoc/advanced_topics_virtualization.adoc
@@ -418,7 +418,7 @@ guests, which are managed by [library]``libvirt``
 
 
 [[sec.virtualization.autoinstall.req_vmhost.salt]]
-===== {vmhost} setup on Salt clients.
+==== {vmhost} setup on Salt clients.
 
 
 If the {vmhost} is registered as a Salt minion, a final configuration step is needed in order to gather all the guest VMs defined on the {vmhost}:
@@ -429,7 +429,7 @@ If the {vmhost} is registered as a Salt minion, a final configuration step is ne
 
 
 [[sec.virtualization.autoinstall.req_vmhost.traditional]]
-===== {vmhost} setup on Traditional clients.
+==== {vmhost} setup on Traditional clients.
 
 
 Once the registration process is finished and all packages have been installed, enable the [daemon]``osad``

--- a/adoc/advanced_topics_virtualization.adoc
+++ b/adoc/advanced_topics_virtualization.adoc
@@ -418,18 +418,18 @@ guests, which are managed by [library]``libvirt``
 
 
 [[sec.virtualization.autoinstall.req_vmhost.salt]]
-==== {vmhost} setup on Salt clients.
+==== {vmhost} setup on Salt clients
 
 
 If the {vmhost} is registered as a Salt minion, a final configuration step is needed in order to gather all the guest VMs defined on the {vmhost}:
 
 
-. From the menu:System Details[Properties] page, enable the menu:Add-on System Type[] ``Virtualization Host`` and confirm by selecting btn:[Update Properties].
-. Schedule a Hardware Refresh. From the system's details page select menu:System Details[Hardware] and click on btn:[Schedule Hardware Refresh].
+. From the menu:System Details[Properties] page, enable the [guimenu]``Add-on System Type`` ``Virtualization Host`` and confirm with btn:[Update Properties].
+. Schedule a Hardware Refresh. On the menu:System Details[Hardware] page click btn:[Schedule Hardware Refresh].
 
 
 [[sec.virtualization.autoinstall.req_vmhost.traditional]]
-==== {vmhost} setup on Traditional clients.
+==== {vmhost} setup on Traditional clients
 
 
 Once the registration process is finished and all packages have been installed, enable the [daemon]``osad``

--- a/adoc/bp_chap_troubleshooting.adoc
+++ b/adoc/bp_chap_troubleshooting.adoc
@@ -25,39 +25,6 @@ The cloned virtual machine should have a different UUID from the original (this 
 +
 
 . Make sure your machines have different hostnames and IP addresses, also check that /etc/hosts contains the changes you made and the correct host entries. 
-. Stop rhnsd daemon with: 
-+
-
-----
-# /etc/init.d/rhnsd stop
-----
-+
-or alternatively: 
-+
-
-----
-# rcrhnsd stop
-----
-. Stop osad with: 
-+
-
-----
-# /etc/init.d/osad stop
-----
-+
-or alternativly: 
-+
-
-----
-# rcosad stop
-----
-. Remove the osad authentication configuration file and the systemid with: 
-+
-
-----
-# rm -f /etc/sysconfig/rhn/{osad-auth.conf,systemid}
-----
-
 
 The next step you take will depend on the Operating System of the clone. 
 


### PR DESCRIPTION
This PR makes the following changes in the documentation:
- Add notes about how to enable a Salt client as "Virtualization Host"
- Remove deprecated steps (from traditional clients) in "Registering a Cloned Salt Minion with SUSE Manager"

This changes has been suggested as outcome of this: https://github.com/SUSE/spacewalk/issues/4192