### PR TITLE
Lower requirements for virt guests management.

### DIFF
--- a/adoc/advanced_topics_virtualization.adoc
+++ b/adoc/advanced_topics_virtualization.adoc
@@ -519,8 +519,10 @@ Web interface if the following requirements are met:
 
 * {vmhost} must be a {kvm} or {xen} host.
 * [daemon]``libvirtd`` must be running on {vmhost} .
-* {vmhost} and {vmguest} must be registered with {susemgr} .
+* {vmhost} must be registered with {susemgr} .
 
+If, in addition, you want to see the profile of the {vmguest} , install
+packages, etc, you also need to register it with {susemgr} .
 
 All actions can be triggered in the {susemgr}
 Web interface from the menu:Virtualization[]

--- a/adoc/advanced_topics_virtualization.adoc
+++ b/adoc/advanced_topics_virtualization.adoc
@@ -519,10 +519,9 @@ Web interface if the following requirements are met:
 
 * {vmhost} must be a {kvm} or {xen} host.
 * [daemon]``libvirtd`` must be running on {vmhost} .
-* {vmhost} must be registered with {susemgr} .
+* {vmhost} must be registered with {susemgr}.
 
-If, in addition, you want to see the profile of the {vmguest} , install
-packages, etc, you also need to register it with {susemgr} .
+In addition, if you want to see the profile of the {vmguest}, install packages, etc., you must also register it with {susemgr}.
 
 All actions can be triggered in the {susemgr}
 Web interface from the menu:Virtualization[]


### PR DESCRIPTION
In the case the user just wants to restart VMs, stop them, etc,
it is not needed to register them.