### PR TITLE
Change diskspace requirement for RES from 200 to 250GB

### DIFF
--- a/adoc/quickstart3_chap_install_overview.adoc
+++ b/adoc/quickstart3_chap_install_overview.adoc
@@ -147,7 +147,7 @@ endif::[]
 |                          | _Production Server_ Minimum 32 GB
 | Disk Space:              | [path]``/`` _(root) The default JeOS root partition size of 24 GB is sufficient for this guide_
 |                          | [path]``/var/lib/pgsql`` Minimum 50 GB
-|                          | [path]``/var/spacewalk`` Minimum 50 GB per SUSE product and 200 GB per Red Hat product
+|                          | [path]``/var/spacewalk`` Minimum 50 GB per SUSE product and 250 GB per Red Hat product
 |===
 
 == Base Host Operating System


### PR DESCRIPTION
@0rnela synced RES 6.9, and it required ~230GB.