### PR TITLE
Unify terminology and simplify wording

### DIFF
--- a/adoc/quickstart3_chap_suma_setup_with_yast.adoc
+++ b/adoc/quickstart3_chap_suma_setup_with_yast.adoc
@@ -116,7 +116,7 @@ image::quickstart-mgr-setup9.png[scaledwidth=80%]
 . Click btn:[Yes] to run setup when prompted.
 
 . Once setup has completed, click btn:[Next] to continue.
-You will see the link to the {susemgr} {webui}.
+You will see the address of the {susemgr} {webui}.
 +
 
 . Click btn:[Finish] to complete {susemgr} setup.
@@ -138,7 +138,7 @@ For security it is recommended that the main administrator creates _low level ad
 
 [[suma.setup.admin.account]]
 .Procedure: Setup the Main Administration Account
-. In the browser, enter the link provided after completing setup and open the {susemgr} {webui}.
+. In the browser, enter the address provided after completing setup and open the {susemgr} {webui}.
 
 . Add your organization name to the menu:Create Organization[Organization Name] field.
 

--- a/adoc/quickstart3_chap_suma_setup_with_yast.adoc
+++ b/adoc/quickstart3_chap_suma_setup_with_yast.adoc
@@ -116,7 +116,7 @@ image::quickstart-mgr-setup9.png[scaledwidth=80%]
 . Click btn:[Yes] to run setup when prompted.
 
 . Once setup has completed, click btn:[Next] to continue.
-You will be presented with the new {susemgr} {webui} address.
+You will see the link to the {susemgr} {webui}.
 +
 
 . Click btn:[Finish] to complete {susemgr} setup.
@@ -138,7 +138,7 @@ For security it is recommended that the main administrator creates _low level ad
 
 [[suma.setup.admin.account]]
 .Procedure: Setup the Main Administration Account
-. Open a browser and direct it to the {susemgr} Server URL provided after completing setup.
+. In the browser, enter the link provided after completing setup and open the {susemgr} {webui}.
 
 . Add your organization name to the menu:Create Organization[Organization Name] field.
 


### PR DESCRIPTION
Instead of two terms (address and URL) use a single one.  Maybe, link would be ok (it's a third one, though).