### PR TITLE
"Web UI" instead of "WebUI"

### DIFF
--- a/adoc/entities.adoc
+++ b/adoc/entities.adoc
@@ -23,7 +23,7 @@ ifdef::env-github,backend-html5,backend-docbook5[]
 :susemgrproxy: SUSE Manager Proxy
 :productnumber: 3.2
 :saltversion: 2018.3.0
-:webui: WebUI
+:webui: Web UI
 // SUSE Product Entities
 :sles-version: 12
 :sp-version: SP3


### PR DESCRIPTION
The documentation team tries to avoid camelCASE as much as possible