### PR TITLE
no need to mention non-systemd; fix menu

### DIFF
--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -394,4 +394,4 @@ systemctl restart salt-minion
 ----
 
 Your newly registered minion should now show up within the {webui} under menu:Salt[Keys].
-Accept the [guimenu]``Pending`` key to begin management.
+Accept the [guimenu]``pending`` key to begin management.

--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -392,14 +392,6 @@ master:`FQDN.SUSE.Manager.com`
 ----
 systemctl restart salt-minion
 ----
-+
 
-or on non-systemd OS:
-+
-
-----
-rcsalt-minion restart
-----
-//TODO Update this is incorrect, onboarding was removed.
-Your newly registered minion should now show up within the {webui} under menu:Salt[Onboarding].
-Accept the key to begin management.
+Your newly registered minion should now show up within the {webui} under menu:Salt[Keys].
+Accept the [guimenu]``Pending`` key to begin management.


### PR DESCRIPTION
* In GS, no need to talk about non-systemd systems
* The menu is now call Salt[Keys]