### PR TITLE
fixing build error

### DIFF
--- a/adoc/command-line-tools.adoc
+++ b/adoc/command-line-tools.adoc
@@ -963,8 +963,8 @@ You can then invoke the command with the appropriate repository name to create t
 # mgr-create-bootstrap-repo --with-custom-channels
 ----
 
+.Flushing a Bootstrap Repository to Remove Custom Channels
 [NOTE]
-. Flushing a Bootstrap Repository to Remove Custom Channels
 ====
 If you create a bootstrap repository that contains custom channels, and later attempt to rebuild with the [code]``mgr-create-bootstrap-repo`` command, the custom channel information will remain in the bootstrap repository.
 If you want to remove custom channel information from your bootstrap repository, you will need to use the [code]``flush`` option when you rebuild:


### PR DESCRIPTION
@keichwa reported:

> 'make suma-html' in develop fails for me with:
> 
> /ssd180/ke/github/doc-susemanager/build/.profiled/noprofile/MAIN-manager.xml:20165:32: error: value of attribute "numeration" is invalid; must be equal to "arabic", "loweralpha", "lowerroman", "upperalpha" or "upperroman"
> /usr/share/daps/make/validate.mk:40: recipe for target '/ssd180/ke/github/doc-susemanager/build/.profiled/noprofile/.validate' failed
> 
> 
> In MAIN-manager.xml I see:
> 
> <orderedlist numeration="NOTE">
> 
> Not sure whether that's the cause of the trouble and how it ended up
> there at all.  Can you repo it?

The error, in line 20165 of the generated XML file, can be traced back to the adoc file command-line-tools, on line 966, which had a malformed title on an admonition. This patch fixes that file, and the build is working successfully locally:

> HTML book built with REMARKS=0, DRAFT=no and META=0:
> /home/lbrindley/doc-susemanager/build/create-all/html/create-all/
> user    0m57.12s
> sys     0m0.35s