### PR TITLE
Forbid dot characters in the configuration channels label

### DIFF
--- a/adoc/reference-webui-configuration.adoc
+++ b/adoc/reference-webui-configuration.adoc
@@ -191,7 +191,7 @@ To create a new central configuration channel:
 .Procedure: Creating Central Configuration Channel
 . Click the [guimenu]``Create Config Channel`` link in the upper right corner of this screen.
 . Enter a name for the channel.
-. Enter a label for the channel. This field must contain only alphanumeric characters, "-" and "_".
+. Enter a label for the channel. This field must contain only letters, numbers, hyphens (``-``) and underscores (``_``).
 . Enter a mandatory description for the channel that allows you to distinguish it from other channels. No character restrictions apply.
 . Click the btn:[Create Config Channel] button to create the new channel.
 . The following page is a subset of the [guimenu]``Channel Details`` page and has three tabs: [guimenu]``Overview`` , [guimenu]``Add Files`` , and [guimenu]``Systems`` . The [guimenu]``Channel Details`` page is discussed in <<config-config-channels-channel-details>>.
@@ -203,7 +203,7 @@ To create a new state channel with an [path]``init.sls`` file:
 .Procedure: Creating State Channel [Salt]
 . Click the [guimenu]``Create State Channel`` link in the upper right corner of this screen.
 . Enter a name for the channel.
-. Enter a label for the channel. This field must contain only alphanumeric characters, "-" and "_".
+. Enter a label for the channel. This field must contain only letters, numbers, hyphens (``-``) and underscores (``_``).
 . Enter a mandatory description for the channel that allows you to distinguish it from other channels. No character restrictions apply.
 . Enter the [guimenu]``SLS Contents`` for the [path]``init.sls`` file.
 . Click the btn:[Create Config Channel] button to create the new channel.

--- a/adoc/reference-webui-configuration.adoc
+++ b/adoc/reference-webui-configuration.adoc
@@ -191,7 +191,7 @@ To create a new central configuration channel:
 .Procedure: Creating Central Configuration Channel
 . Click the [guimenu]``Create Config Channel`` link in the upper right corner of this screen.
 . Enter a name for the channel.
-. Enter a label for the channel. This field must contain only alphanumeric characters, "-", "_", and ".".
+. Enter a label for the channel. This field must contain only alphanumeric characters, "-" and "_".
 . Enter a mandatory description for the channel that allows you to distinguish it from other channels. No character restrictions apply.
 . Click the btn:[Create Config Channel] button to create the new channel.
 . The following page is a subset of the [guimenu]``Channel Details`` page and has three tabs: [guimenu]``Overview`` , [guimenu]``Add Files`` , and [guimenu]``Systems`` . The [guimenu]``Channel Details`` page is discussed in <<config-config-channels-channel-details>>.
@@ -203,7 +203,7 @@ To create a new state channel with an [path]``init.sls`` file:
 .Procedure: Creating State Channel [Salt]
 . Click the [guimenu]``Create State Channel`` link in the upper right corner of this screen.
 . Enter a name for the channel.
-. Enter a label for the channel. This field must contain only alphanumeric characters, "-", "_", and ".".
+. Enter a label for the channel. This field must contain only alphanumeric characters, "-" and "_".
 . Enter a mandatory description for the channel that allows you to distinguish it from other channels. No character restrictions apply.
 . Enter the [guimenu]``SLS Contents`` for the [path]``init.sls`` file.
 . Click the btn:[Create Config Channel] button to create the new channel.


### PR DESCRIPTION
These are not allowed anymore because they cause problem in salt (salt interprets `.` as a separator character).

@jcayouette This change should go to 3.2 documentation. I created a PR against `develop` - is that correct or should I have used another branch?