### PR TITLE
update feedback info; reported by Meike

### DIFF
--- a/adoc/common_intro_feedback_i.adoc
+++ b/adoc/common_intro_feedback_i.adoc
@@ -10,9 +10,9 @@ To report bugs for a product component, go to https://scc.suse.com/support/reque
 
 User Comments::
 We want to hear your comments about and suggestions for this manual and the other documentation included with this product.
-Use the User Comments feature at the bottom of each page in the online documentation or go to http://www.suse.com/doc/feedback.html and enter your comments there. 
+Use the User Comments feature at the bottom of each page in the online documentation.
 
 Mail::
-For feedback on the documentation of this product, you can also send a mail to mailto:doc-team@suse.de[<doc-team@suse.de>].
+For feedback on the documentation of this product, you can also send a mail to mailto:doc-team@suse.de[<doc-team@suse.com>].
 Make sure to include the document title, the product version and the publication date of the documentation.
-To report errors or suggest enhancements, provide a concise description of the problem and refer to the respective section number and page (or URL). 
+To report errors or suggest enhancements, provide a concise description of the problem and refer to the respective section number and page (or URL).


### PR DESCRIPTION
@chabowski reported outdated feedback info:

* feedback page no longer exists
* new feedback address (doc-team@suse.com)