### PR TITLE
Fix: specify which AK can be used when image building

### DIFF
--- a/adoc/advanced_topics_image_management.adoc
+++ b/adoc/advanced_topics_image_management.adoc
@@ -121,6 +121,8 @@ salt '$your_minion' state.highstate
 
 Create an activation key associated with the channel that your images will use.
 
+NOTE: only activation keys associated with a channel that is not "SUSE Manager Default" can be used to build Containers.
+
 image::systems_create_activation_key.png[scaledwidth=80%]
 
 . Select menu:Main Menu[Systems > Activation Keys].
@@ -520,6 +522,8 @@ Make sure your build source Kiwi configuration contains `rhn-org-trusted-ssl-cer
 
 Create an activation key associated with the channel that your images will use.
 Activation keys are mandatory for OS Image building.
+
+NOTE: only activation keys associated with a channel that is not "SUSE Manager Default" can be used to build Containers.
 
 image::systems_create_activation_key.png[scaledwidth=80%]
 

--- a/adoc/advanced_topics_image_management.adoc
+++ b/adoc/advanced_topics_image_management.adoc
@@ -121,7 +121,7 @@ salt '$your_minion' state.highstate
 
 Create an activation key associated with the channel that your images will use.
 
-NOTE: only activation keys associated with a channel that is not "SUSE Manager Default" can be used to build Containers.
+NOTE: To build containers, you will need an activation key that is associated with a channel other than "SUSE Manager Default".
 
 image::systems_create_activation_key.png[scaledwidth=80%]
 
@@ -523,7 +523,7 @@ Make sure your build source Kiwi configuration contains `rhn-org-trusted-ssl-cer
 Create an activation key associated with the channel that your images will use.
 Activation keys are mandatory for OS Image building.
 
-NOTE: only activation keys associated with a channel that is not "SUSE Manager Default" can be used to build Containers.
+NOTE: To build containers, you will need an activation key that is associated with a channel other than "SUSE Manager Default".
 
 image::systems_create_activation_key.png[scaledwidth=80%]
 

--- a/adoc/advanced_topics_image_management.adoc
+++ b/adoc/advanced_topics_image_management.adoc
@@ -121,7 +121,11 @@ salt '$your_minion' state.highstate
 
 Create an activation key associated with the channel that your images will use.
 
-NOTE: To build containers, you will need an activation key that is associated with a channel other than "SUSE Manager Default".
+[NOTE]
+.Relationship Between Activation Keys and Image Profiles
+====
+To build containers, you will need an activation key that is associated with a channel other than "SUSE Manager Default".
+====
 
 image::systems_create_activation_key.png[scaledwidth=80%]
 
@@ -523,7 +527,11 @@ Make sure your build source Kiwi configuration contains `rhn-org-trusted-ssl-cer
 Create an activation key associated with the channel that your images will use.
 Activation keys are mandatory for OS Image building.
 
-NOTE: To build containers, you will need an activation key that is associated with a channel other than "SUSE Manager Default".
+[NOTE]
+.Relationship Between Activation Keys and Image Profiles
+====
+To build OS Images, you will need an activation key that is associated with a channel other than "SUSE Manager Default".
+====
 
 image::systems_create_activation_key.png[scaledwidth=80%]
 


### PR DESCRIPTION
Add a tiny note about activation keys and image building.