### PR TITLE
Update quickstart3_chap_suma_keys_and_first_client.adoc

### DIFF
--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -203,7 +203,7 @@ image::mgr_configuration_bootstrap_trad.png[scaledwidth=80%]
 [WARNING]
 .Using SSL
 ====
-It is not recommended that you clear the [command]``Enable SSL`` checkbox in the {webui}, or set [command]``USING_SSL=0`` in the bootstrap script.
+It is not recommended that you clear the [guimenu]``Enable SSL`` checkbox in the {webui}, or set `USING_SSL=0` in the bootstrap script.
 If you disable SSL, the registration process will not complete successfully unless you manage custom CA certificates.
 ====
 +
@@ -250,7 +250,7 @@ cp bootstrap.sh bootstrap-sles12.sh
 
 . Open [path]``sles12.sh`` for modification.
 Scroll down and modify both lines marked in green.
-Comment out [path]``exit 1`` with a hash mark ([command]``#``) to activate the script, then enter the name of the key for this script in the [path]``ACTIVATION_KEYS=` field:
+Comment out `exit 1` with a hash mark (`\#`) to activate the script, then enter the name of the key for this script in the `ACTIVATION_KEYS=` field:
 +
 
 ----
@@ -325,17 +325,17 @@ The feature is not currently supported on {rhel} or Salt clients.
 ====
 
 .Procedure: Using Package Locks
-. On the client machine, install the [command]``zypp-plugin-spacewalk`` package:
+. On the client machine, install the [package]``zypp-plugin-spacewalk`` package:
 +
 ----
 # zypper in zypp-plugin-spacewalk
 ----
 
 . Navigate to the menu:Software[Packages > Lock] tab on the managed system to see a list of all available packages.
-. Select the packages to lock, and click [btn]``Request Lock``.
+. Select the packages to lock, and click btn:[Request Lock].
 You can also choose to enter a date and time for the lock to activate.
 Note that even if you do not select a date and time, the lock might not activate immediately.
-. To remove a package lock, select the packages to unlock and click [btn]``Request Unlock``.
+. To remove a package lock, select the packages to unlock and click btn:[Request Unlock].
 You can also choose to enter a date and time for the lock to deactivate.
 Note that even if you do not select a date and time, the lock might not deactivate immediately.
 


### PR DESCRIPTION
At some places (for literal strings), we'd better simply use plain backticks, etc.
Partially reverted your changes.