### PR TITLE
remove info here no longer or not needed at all

### DIFF
--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -178,7 +178,7 @@ The following procedure will guide you through generating a bootstrap script.
 [[create.boot.script]]
 .Procedure: Creating a Bootstrap Script
 . From the {productname} {webui}, browse to menu:Main Menu[Admin > Manager Configuration > Bootstrap Script]. For more information, see <<s3-sattools-config-bootstrap>>.
-. Uncheck menu:SUSE Manager Configuration - Bootstrap[Bootstrap Script > Bootstrap using Salt].
+. In the [guimenu]``SUSE Manager Configuration - Bootstrap`` dialog disable [guimenu]``Bootstrap using Salt``.
 Use default settings and click the btn:[Update] button.
 +
 

--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -165,26 +165,11 @@ Two of these important parameters are:
 
 
 [NOTE]
-.Using the --traditional [option]
-====
-As of {productname} 3.1 the [command]``--traditional`` option must be used if creating a bootstrap script from the command line via the [command]``mgr-bootstrap`` command for traditional clients.
-Generated bootstrap scripts target Salt minions by default.
-====
-
-[NOTE]
-.Bootstrap Scripting Best Practices
-====
-It is possible to use various methods to register clients for use with {productname} in mass using bootstrap.
-Using batch scripts for mass registration of both VM and Bare Metal machines is a possibility.
-Some of these methods will be covered in the [ref]_Best Practices Guide_ and will be added as examples at a later time.
-====
-
-[IMPORTANT]
 .SLES 15 and Python 3
 ====
-SLES 15 utilizes Python 3 as its default system version. Due to this change any older
-bootstrap scripts(based on python 2) must be re-created for SLES 15 systems. Attempting to
-register SLES 15 systems with SUSE Manager using Python 2 versions of the bootstrap script will
+SLES 15 utilizes Python 3 by default.  Because of this change any older
+bootstrap scripts (based on python 2) must be re-created for SLES 15 systems. Attempting to
+register SLES 15 systems with {susemgr} using Python 2 versions of the bootstrap script will
 fail.
 ====
 
@@ -350,13 +335,6 @@ The following section describes the first method and uses a bootstrap repository
 The second method is to create a bootstrap script using [command]``mgr-bootstrap``.
 Bootstrapping Salt minions with [command]``mgr-bootstrap`` is performed in the same manner as bootstrapping traditional clients; for more information, see <<registering.clients.traditional>>.
 The third method is performed from the {productname} {webui}; find this method located in <<ref.webui.systems.bootstrapping>>.
-
-.Deprecation Warning
-[IMPORTANT]
-====
-The [command]``mgr-bootstrap --salt`` option will be deprecated as of SUSE Manager 3.1.
-To bootstrap a Salt minion call [command]``mgr-bootstrap`` from the command line as you would for a traditional system.
-====
 
 
 The following section assumes you have created a SUSE Manager tools repository.


### PR DESCRIPTION
I like to propose to remove old or confusing admonitions.  command line tools are not subject of this chapter and on 3.2 we must no longer warn about things introduced with 3.1.