### PR TITLE
Update public-cloud-setup.adoc

### DIFF
--- a/adoc/public-cloud-setup.adoc
+++ b/adoc/public-cloud-setup.adoc
@@ -169,7 +169,7 @@ For an update of the DNS records for the instance within the DNS service of your
 If you run a {productname} Server instance, you can run YaST after the instance is launched to ensure the external storage is attached and prepared according to <<using-separate-storage-volume>>, and the DNS resolution is set up as described:
 
 ----
-$ /sbin/yast2 susemanagersetup
+$ /sbin/yast2 susemanager_setup
 ----
 
 
@@ -326,7 +326,7 @@ If your cloud framework recommends to add an fstab entry, add the following line
 +
 
 ----
-/dev/sdb1 /manager_storage xfs defaults 1 1
+/dev/sdb1 /manager_storage xfs defaults,nofail 1 1
 ----
 
 


### PR DESCRIPTION
The yast2 command was incorrect, and fails.
If you do not mount the disk with nofail, it is possible that the system will not boot. In the cloud frameworks, there is no way to interrupt the boot sequence. 