### PR TITLE
Docs: Kiwi OS Image building will be enabled by default

### DIFF
--- a/adoc/advanced_topics_image_management.adoc
+++ b/adoc/advanced_topics_image_management.adoc
@@ -374,23 +374,6 @@ They can be of various types: PXE, QCOW2, LiveCD images, and others.
 
 For more information about the Kiwi build system, see the https://doc.opensuse.org/projects/kiwi/doc/[Kiwi documentation].
 
-
-
-[[at.images.kiwi.enablement]]
-=== Enabling OS Image Building
-
-OS image building is disabled by default. You can enable it in `/etc/rhn/rhn.conf` by setting:
-
-----
-java.kiwi_os_image_building_enabled = true
-----
-
-Restart the Spacewalk service to pick up the changes:
-
-----
-spacewalk-service restart
-----
-
 [[at.images.kiwi.requirements]]
 === Requirements
 

--- a/book-to-set/MAIN-manager.xml
+++ b/book-to-set/MAIN-manager.xml
@@ -17891,11 +17891,6 @@ This will result in an <literal>unknown</literal> update status.</para>
 <section xml:id="at.images.kiwi"><title>OS Images</title><simpara>OS images are built by the Kiwi image system.
 They can be of various types: PXE, QCOW2, LiveCD images, and others.</simpara>
 <simpara>For more information about the Kiwi build system, see the <link xl:href="https://doc.opensuse.org/projects/kiwi/doc/">Kiwi documentation</link>.</simpara>
-<section xml:id="at.images.kiwi.enablement"><title>Enabling OS Image Building</title><simpara>OS image building is disabled by default. You can enable it in <literal>/etc/rhn/rhn.conf</literal> by setting:</simpara>
-<screen>java.kiwi_os_image_building_enabled = true</screen>
-<simpara>Restart the Spacewalk service to pick up the changes:</simpara>
-<screen>spacewalk-service restart</screen>
-</section>
 <section xml:id="at.images.kiwi.requirements"><title>Requirements</title><simpara>The Kiwi image building feature is available for Salt minions running SUSE Linux Enterprise Server&#160;12 or later.</simpara>
 <simpara>Kiwi image configuration files and configuration scripts must be accessible in one of these locations:</simpara>
 <itemizedlist>


### PR DESCRIPTION
Kiwi OS image building will be enabled by default with:

https://github.com/SUSE/spacewalk/pull/5905

With this PR we remove from the manual the section to explain how to enable the feature.

Related issue:

https://github.com/SUSE/spacewalk/issues/5802

