### PR TITLE
fix entity defs

### DIFF
--- a/adoc/entities.adoc
+++ b/adoc/entities.adoc
@@ -44,7 +44,7 @@
 :openscap: OpenSCAP
 :uarr:
 :ncc: Novell Customer Center
-:smtool: Subscription Management
+:smtool: Subscription Management Tool
 :rmtool: Repository Management Tool
 :vmguest: VM Guest
 :vmhost: VM Host Server

--- a/adoc/entities.adoc
+++ b/adoc/entities.adoc
@@ -18,6 +18,7 @@
 :saltversion: 2018.3.0
 :webui: Web UI
 :sles-version: 12
+:sp-ver: 3
 :sp-version: SP3
 :sp-version-l: sp3
 :jeos: JeOS
@@ -26,7 +27,7 @@
 :sle: SUSE Linux Enterprise
 :slsa: SLES
 :suse: SUSE
-:slea: {sle}
+:slea: SLE
 :sleda: SLED
 :ay: AutoYaST
 :baseos:
@@ -34,7 +35,7 @@
 :upgrade: Upgrade Guide
 :yast: YaST
 :rootuser: root
-:mdash: -
+:mdash: —
 :rhela: RHEL
 :mgradvtop: Advanced Topics Guide
 :mgrgetstart: Getting Started Guide
@@ -43,8 +44,7 @@
 :openscap: OpenSCAP
 :uarr:
 :ncc: Novell Customer Center
-:sp-ver: {sp-version}
-:smtool: {rmtool}
+:smtool: Subscription Management
 :rmtool: Repository Management Tool
 :vmguest: VM Guest
 :vmhost: VM Host Server


### PR DESCRIPTION
In our context, smt != rmt (on version 12 you can continue using smt).
The others are probably obvious.

We probably also want it in maint/3.2.