### PR TITLE
Fixed table layout

### DIFF
--- a/adoc/reference-webui-systems.adoc
+++ b/adoc/reference-webui-systems.adoc
@@ -1807,56 +1807,108 @@ The following table provides information on what actions may be performed across
 These two methods have different actions which may be accessed with the System Set Manager:
 
 
-[cols="1,1,1", options="header"]
+[cols="1a,1a,1a", options="header"]
 |===
-| System Set Manager: Overview | Traditional SSM | Salt SSM
-
+| System Set Manager: Overview
+| Traditional SSM
+| Salt SSM
 | Systems:
-* List Systems | Supported * Supported | Supported * Supported
+
+* List Systems
+
+| Supported
+
+* Supported
+
+| Supported
+
+* Supported
+
 |Install Patches:
-* Schedule Patch Updates | Supported * Supported | Supported * Supported
+
+* Schedule Patch Updates
+
+| Supported
+
+* Supported
+
+| Supported
+
+* Supported
+
 | Install Packages:
+
 * Upgrade
 * Install
 * Remove
-* Verify | Supported
+* Verify
+
+| Supported
+
 * Supported
 * Supported
 * Supported
-* Supported | Limited
+* Supported
+
+| Limited
+
 * Supported
 * Supported
 * Supported
 * Not Available
+
 | Groups:
+
 * Create
-* Manage | Supported
+* Manage
+
+| Supported
+
 * Supported
-* Supported | Supported
+* Supported
+
+| Supported
+
 * Supported
 * Supported
+
 | Channels:
+
 * Channel Memberships
 * Channel Subscriptions
-* Deploy / Diff Channels | Supported
+* Deploy / Diff Channels
+
+| Supported
+
 * Supported
 * Supported
-* Supported | Limited
+* Supported
+
+| Limited
+
 * Supported
 * Not Available
 * Not Available
+
 | Provisioning:
+
 * Autoinstall Systems
 * Tag for Snapshot
 * Remote Commands
 * Power Management
-* Power Management Operations | Supported
+* Power Management Operations
+
+| Supported
+
 * Supported
 * Supported
 * Supported
 * Supported
-* Supported | Not Available
+* Supported
+
+| Not Available
 | Misc:
+
 * Update System Preferences
 * Update Hardware Profiles
 * Update Package Profiles
@@ -1864,17 +1916,10 @@ These two methods have different actions which may be accessed with the System S
 * Set and Remove Custom Values for Selected Systems
 * Reboot Systems
 * Migrate Systems to another Organization
-* Delete Systems from SUSE Manager | Supported
-* Supported
-* Supported
-* Supported
-* Supported
-* Supported
-* Supported
-* Supported
-* Supported
-* Supported
-* Supported | Supported
+* Delete Systems from SUSE Manager
+
+| Supported
+
 * Supported
 * Supported
 * Supported
@@ -1885,6 +1930,20 @@ These two methods have different actions which may be accessed with the System S
 * Supported
 * Supported
 * Supported
+
+| Supported
+
+* Supported
+* Supported
+* Supported
+* Supported
+* Supported
+* Supported
+* Supported
+* Supported
+* Supported
+* Supported
+
 |===
 
 


### PR DESCRIPTION
According to https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#tables you need the 'a' signifier in the cols attribute to say that there's asciidoc content in the column. From there, you need to make sure that there's a line above and below each list.