### PR TITLE
Bootstrap using Salt option for Salt clients (#246)

### DIFF
--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -313,7 +313,7 @@ Note that even if you do not select a date and time, the lock might not deactiva
 
 There are currently three methods for registering Salt minions.
 This section describes the first method and uses a bootstrap repository.
-The second method uses bootstrap script, and is described in <<registering.clients.traditional>>.
+The second method uses the bootstrap script, and is mostly similar to the procedure described in <<registering.clients.traditional>>{mdash}the difference is enabling [guimenu]``Bootstrap using Salt`` and [guimenu]``Enable Remote Commands`` ([literal]``ALLOW_REMOTE_COMMANDS=1``).
 The third method uses the {webui}, and is described in <<ref.webui.systems.bootstrapping>>.
 
 You can also use these methods to change existing traditional clients into Salt minions.


### PR DESCRIPTION
* Bootstrap using Salt option for Salt clients

clarification about the difference when using the bootstrap script for
Salt clients. Keep the option enabled (what's the default).

Enable 'Remote Commands' is mandatory.