### PR TITLE
1-by-1 branch server install and empty profile usage

### DIFF
--- a/adoc/retail_migr_chap_slepostosuma.adoc
+++ b/adoc/retail_migr_chap_slepostosuma.adoc
@@ -120,11 +120,6 @@ For each branch perform the following steps:
 // Use the empty profiles together with activation keys to onboard all the systems of your infrastructure.
 // Use an activation key to assign the channels listed in https://www.suse.com/documentation/suse-manager-for-retail-3-2/retail-getting-started/retail.chap.install.html[Configuring Server].
 
-. To finalize each branch server migration, you must install the branch server machine as a Salt-based minion and bootstrap it as a proxy.
-For more information about proxy installation, see xref:retail_chap_install.adoc#retail.sect.install.branch[Installing and Registering].
-For more information about using an activation key to assign the required channels, see xref:retail_chap_install.adoc#retail.sect.install.install.config[Configuring Server].
-After onboarded to {smr}, the branch server machine is connected with the empty profile (by FQDN), and so it will get the Retail configuration.
-
 . Run the import command for one branch after the other:
 +
 ----
@@ -132,6 +127,11 @@ retail_yaml --from-yaml retail.yml --branch <branch_name>
 ----
 +
 Repeat the command for every branch.
+
+. To finalize each branch server migration, you must install the branch server machine as a Salt-based minion and bootstrap it as a proxy.
+For more information about proxy installation, see xref:retail_chap_install.adoc#retail.sect.install.branch[Installing and Registering].
+For more information about using an activation key to assign the required channels, see xref:retail_chap_install.adoc#retail.sect.install.install.config[Configuring Server].
+After onboarded to {smr}, the branch server machine is connected with the empty profile (by FQDN), and so it will get the Retail configuration.
 
 . Apply highstate on the branch server; this will happen automatically if [guimenu]``Configuration
 File Deployment`` is enabled.


### PR DESCRIPTION
swap step order in branch server installation procedure as proposed by @nadvornik ; otherwise empty profile usage would not be correct.