### PR TITLE
Delete general warning about network configuration

### DIFF
--- a/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
+++ b/adoc/quickstart3_chap_suma_keys_and_first_client.adoc
@@ -342,19 +342,6 @@ The rest of this section assumes you have created a SUSE Manager tools repositor
 You can review creating a tools repository in <<create.tools.repository>>.
 
 
-[WARNING]
-.Ensure the Salt Master is Reachable During Bootstrap
-====
-The Salt master and its proxy should always be reachable via both IP address and the FQDN.
-In the following rare scenario:
-
-* The Salt master (SUSE Manager) is in some DNS.
-* Your Minions are in a different subnet bound to an alternate DNS and the Salt master record is absent.
-* The Salt master cannot know that the minion is not utilizing the same DNS record. The the Salt master nevertheless sends the FQDN of itself to the minion expecting it to join.
-* The minion looks for a different DNS, one where the master record does not exist therefore bootstrap fails.
-
-====
-
 
 When you have fully synchronized a base channel from the {webui} for clients to obtain software packages from (for example: `SLES12-SP4-Pool_for_x86_64`) perform the following procedure to register a Salt minion.
 


### PR DESCRIPTION
In the context of the GS, this info is superfluous.  In a positive
way, it is already provided in the "1.2.4 Network Requirements" section.

When approved, we can also submit it to maint/3.2