### PR TITLE
Schedule a channel state for minions if an assigned channel to them is deleted.

### DIFF
--- a/adoc/reference-webui-channels.adoc
+++ b/adoc/reference-webui-channels.adoc
@@ -354,7 +354,7 @@ This page lists the settings made during channel creation.
 
 [WARNING]
 ====
-If you delete a channel that has been assigned to a set of minions, it will trigger an immediate update of the channel state.
+If you delete a channel that has been assigned to a set of minions, it will trigger an immediate update of the channel state for any minions associated with the deleted channel.
 This is to ensure that the changes are reflected accurately in the repository file.
 ====
 

--- a/adoc/reference-webui-channels.adoc
+++ b/adoc/reference-webui-channels.adoc
@@ -351,6 +351,13 @@ This page lists the settings made during channel creation.
 ==== menu:Channel Details[Managers]
 
 {productname} administrators and channel administrators may alter or delete any channel.
+
+[WARNING]
+====
+When a channel is deleted that is already assigned to a set of minions then for those minions, an application of channel state will scheduled
+immediately to reflect changes in system's repo file.
+====
+
 To grant other users rights to alter or delete this channel, check the box next to the user's name and click btn:[Update].
 
 To allow all users to manage the channel, click the btn:[Select All] button at the bottom of the list then click btn:[Update].

--- a/adoc/reference-webui-channels.adoc
+++ b/adoc/reference-webui-channels.adoc
@@ -354,8 +354,8 @@ This page lists the settings made during channel creation.
 
 [WARNING]
 ====
-When a channel is deleted that is already assigned to a set of minions then for those minions, an application of channel state will scheduled
-immediately to reflect changes in system's repo file.
+If you delete a channel that has been assigned to a set of minions, it will trigger an immediate update of the channel state.
+This is to ensure that the changes are reflected accurately in the repository file.
 ====
 
 To grant other users rights to alter or delete this channel, check the box next to the user's name and click btn:[Update].


### PR DESCRIPTION
When deleting a channel, channel was being removed correctly from database but in case of minion, channel was still assigned to the system. With this PR, we schedule salt state to update the minion as well.