### PR TITLE
enable-scc subcommand is not available anymore

### DIFF
--- a/adoc/command-line-tools.adoc
+++ b/adoc/command-line-tools.adoc
@@ -713,7 +713,6 @@ Show help message and exit.
 With [command]``mgr-sync`` you may add or synchronize products and channels.
 The [command]``mgr-sync`` command also enables and refreshes SCC data.
 
-This tool requires that SCC is enabled by running [command]``mgr-sync enable-scc`` first (Enabled by default in {productname} 2.1 and greater).
 
 By default, log rotation of [path]``spacewalk-repo-sync`` is disabled.
 This logfile is run by a cron job, and managed by a configuration file.
@@ -733,8 +732,6 @@ For a complete list of command line option, see the mgr-sync manpage (man mgr-sy
 Basic actions are:
 
 ----
-mgr-sync enable-scc
-
 mgr-sync list channel(s)|product(s)|credentials
 mgr-sync add  channel(s)|product(s)|credentials
 mgr-sync delete  credentials


### PR DESCRIPTION
The "mgr-sync enable-scc" subcommand is not available anymore.
We removed it and the docs should reflect this.

Even 3.1 and 3.2 does not have it anymore.