### PR TITLE
Correct the supported OS for OS image build hosts

### DIFF
--- a/adoc/advanced_topics_image_management.adoc
+++ b/adoc/advanced_topics_image_management.adoc
@@ -402,7 +402,7 @@ For more information, see the documentation of the underlying system.
 === Creating a Build Host
 
 To build all kinds of images with {productname}, create and configure a build host.
-OS image build hosts are Salt minions running {sls}{nbsp}12.
+OS image build hosts are Salt minions running {sls}{nbsp}12 (SP3 or later).
 This procedure will guide you though the initial configuration for a build host.
 
 From the {productname} {webui} perform these steps to configure a build host:

--- a/adoc/advanced_topics_image_management.adoc
+++ b/adoc/advanced_topics_image_management.adoc
@@ -54,7 +54,7 @@ For more information on Containers or CaaS Platform, see:
 === Creating a Build Host
 
 To build images with {productname}, you will need to create and configure a build host.
-Build hosts are Salt minions running {sle} 12 or later.
+Container build hosts are Salt minions running {sle} 12 or later.
 This section guides you though the initial configuration for a build host.
 
 From the {productname} {webui} perform these steps to configure a build host.
@@ -402,7 +402,7 @@ For more information, see the documentation of the underlying system.
 === Creating a Build Host
 
 To build all kinds of images with {productname}, create and configure a build host.
-Build hosts are Salt minions running {sls}{nbsp}12 or later.
+OS image build hosts are Salt minions running {sls}{nbsp}12.
 This procedure will guide you though the initial configuration for a build host.
 
 From the {productname} {webui} perform these steps to configure a build host:


### PR DESCRIPTION
Correction: OS image building is exclusively supported on SLES12, including service packs (i.e. not SLES15)

*Suggestions for better wording are welcome* :smiley: 