### PR TITLE
Do not mark vsftp formula as an optional one

### DIFF
--- a/adoc/retail_chap_formulas.adoc
+++ b/adoc/retail_chap_formulas.adoc
@@ -8,6 +8,8 @@ Formulas are pre-written Salt states, that are used to configure your {smr} inst
 
 This section lists the primary formulas shipped with {smr} and their configuration options.
 
+All the formulas in this section must be accurately configured for your {smr} installation to function correctly. If you are unsure of the correct formula configuration details, run the [command]``retail_branch_init`` command before you begin to create the recommended formula configuration. You can then manually edit the formulas as required.
+
 
 .State and formula name collisions
 [IMPORTANT]
@@ -219,13 +221,16 @@ Use only alphanumeric characters for the branch identifier.
 [[retail.sect.formulas.saltboot]]
 == Saltboot Formula
 
-The Saltboot formula is used to configure disk images and partitioning.
+The Saltboot formula is used to configure disk images and partitioning for the selected hardware type.
 
+[IMPORTANT]
+====
+Saltboot formula is meant to be used as a group formula. Enable and configure saltboot formula for hardware type groups.
+====
 
+.Procedure: Configuring the hardware type group with saltboot
 
-.Procedure: Configuring the branch server with saltboot
-
-. Open the details page for your new hardware group, and navigate to the [guimenu]``Formulas`` tab.
+. Open the details page for your new hardware type group, and navigate to the [guimenu]``Formulas`` tab.
 . Select the [systemitem]``saltboot-formula`` and click btn:[Save].
 . Navigate to the new menu:Formulas[Saltboot] tab.
 . In the [guimenu]``Disk 1`` section, set these parameters:
@@ -290,7 +295,6 @@ The TFTPd formula is used to configure the TFTP service on the branch server.
 == VsFTPd Formula
 
 The VsFTPd formula is used to configure the FTP service on the branch server.
-Use of this formula is optional.
 
 
 .Procedure: Configuring VsFTPd

--- a/adoc/retail_chap_install.adoc
+++ b/adoc/retail_chap_install.adoc
@@ -274,7 +274,7 @@ The branch server can be configured automatically using the [command]``retail_br
 If you prefer to manually configure the branch server, you can do so using formulas.
 For more information about formulas, see xref:retail_chap_formulas.adoc#retail.chap.formulas[Formulas].
 
-.Procedure: Configuring branch server formulas
+.Procedure: Configuring branch server formulas using helper script
 
 . Branch server configuration is performed using the [command]``retail_branch_init`` command:
 +
@@ -282,7 +282,7 @@ For more information about formulas, see xref:retail_chap_formulas.adoc#retail.c
 retail_branch_init <branch_server_salt_id>
 ----
 +
-You can use the [command]``retail_branch_init --help`` command for additional options.
+This command will configure branch server formulas with recommended values. You can use the [command]``retail_branch_init --help`` command for additional options.
 . Verify that your changes have been configured correctly by checking the {susemgr} {webui} branch server system formulas.
 . Apply highstate on the branch server.
 You can do this through the {webui}, or by running this command:


### PR DESCRIPTION
Due to upcoming changes in code, vsftp will no longer be optional part.
Explicitely state that for working retail config, all formulas must be
properly configured.