### PR TITLE
2.1 comparison: clarify profile syncing support

### DIFF
--- a/adoc/mgr_product_comparison.adoc
+++ b/adoc/mgr_product_comparison.adoc
@@ -51,7 +51,7 @@ This includes features in development and features available only to their paren
 | Package Verification                                                                 | Supported              | Under Review
 | System Locking                                                                       | Supported              | Under Review
 | Configuration File Management                                                        | Supported              | Supported
-| Snapshots and Profiles                                                               | Supported              | Under Review (Profiles are supported)
+| Snapshots and Profiles                                                               | Supported              | Under Review (Profiles are supported, syncing is not)
 | Power Management                                                                     | Supported              | Coming Soon
 |===
 


### PR DESCRIPTION
In [this bug report](https://bugzilla.suse.com/show_bug.cgi?id=1124013) we are asked about the reason why `spacecmd`'s `system_syncpackages` does not work with minions.

The reason is that the core of this functionality is not yet ported to Salt.