### PR TITLE
Removed Ubuntu trust gpg key sections

### DIFF
--- a/adoc/bp_chap_expanded_support.adoc
+++ b/adoc/bp_chap_expanded_support.adoc
@@ -442,19 +442,6 @@ This section describes how to manually prepare {ubuntu} clients for registration
 deb http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/Ubuntu16.04-SUSE-Manager-Tools/xUbuntu_16.04/ /
 ----
 +
-. From the command line, import the appropriate release key and add it to the keyring:
-+
-----
-curl http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/Ubuntu16.04-SUSE-Manager-Tools/xUbuntu_16.04/Release.key
-sudo apt-key add -
-----
-+
-. Update the repository list in the package manager:
-+
-----
-sudo apt update
-----
-+
 . Edit the [filename]``sudoers`` file:
 +
 ----
@@ -473,19 +460,6 @@ Grant [command]``sudo`` access to the user by adding this line to the [filename]
 +
 ----
 deb http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04/ /
-----
-+
-. From the command line, import the appropriate release key and add it to the keyring:
-+
-----
-curl http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04/Release.key
-sudo apt-key add -
-----
-+
-. Update the repository list in the package manager:
-+
-----
-sudo apt update
 ----
 +
 . Edit the [filename]``sudoers`` file:


### PR DESCRIPTION
This PR removes the section about adding the repository gpg key for Ubuntu minions.
This got automated here: https://github.com/SUSE/spacewalk/pull/7161

~~However: This PR should not be merged until the Ubuntu repositories are signed by the correct key~~