### PR TITLE
Channels sections in Client Cfg & Admin

### DIFF
--- a/modules/administration/nav-administration-guide.adoc
+++ b/modules/administration/nav-administration-guide.adoc
@@ -5,6 +5,8 @@ ifndef::backend-pdf[]
 * xref:intro.adoc[Administration Guide]
 // Image Management
 ** xref:image-management.adoc[Image Management]
+// Channel Management
+** xref:channel-management.adoc[Channel Management]
 // Live Patching
 ** xref:live-patching.adoc[Live Patching]
 // Monitoring

--- a/modules/administration/pages/channel-management.adoc
+++ b/modules/administration/pages/channel-management.adoc
@@ -1,0 +1,37 @@
+[[channel-management]]
+= Channel Management
+// Antora entities
+ifndef::backend-pdf[]
+include::ROOT:partial$entities.adoc[]
+endif::[]
+// PDF entities
+ifdef::backend-pdf[]
+include::_partials/entities.adoc[]
+endif::[]
+
+Channels are a method of grouping software packages.
+
+In {productname}, channels are grouped into base and child channels, with base channels usually grouped by hardware architecture and software version, and child channels being related to a specific base channel.
+
+While {productname}  provides all required channels, you might find it useful to create custom channels specific to your environment.
+{productname} Administrators and Channel Administrators have channel management authority, which gives them the ability to create and manage their own custom channels.
+
+This section gives more detail on how to create, administer, and delete custom channels.
+
+== Create Custom Channels
+
+TODO:: write this
+
+Note that if you include a package tagged with [systemitem]``release`` in your channel, then it will be automatically installed when the channel is installed.
+
+== Administer Custom Channels
+
+TODO:: write this
+
+== Delete Custom Channels
+
+TODO:: write this
+
+Note that when channels are deleted, the packages that are part of the deleted channel are not automatically removed.
+If you try to update packages that have had their channel deleted, it can cause errors.
+In this case, you will need to manually remove the packages.

--- a/modules/administration/pages/channel-management.adoc
+++ b/modules/administration/pages/channel-management.adoc
@@ -34,8 +34,9 @@ Do not create child channels containing packages that are not compatible with th
 
 .Procedure: Create a custom channel
 
-. In the {productname} {webui}, navigate to menu:Software[Manage Software Channels], and click btn:[Create Channel].
+. In the {productname} {webui}, navigate to menu:Software[Manage > Channels], and click btn:[Create Channel].
 . On the [guimenu]``Create Software Channel`` page, give your channel a name (for example, [systemitem]``My Tools SLES 12 SP3 x86_64``) and a label (for example, [systemitem]``my-tools-sles12sp3-x86_64``).
+Note that labels cannot contain space characters or capital letters.
 . In the [guimenu]``Parent Channel`` drop down, choose the relevant base channel (for example [systemitem]``SLES12-SP3-Pool for x86_64``).
 Ensure that you choose the compatible parent channel for your packages.
 . In the [guimenu]``Architecture`` drop down, choose the appropriate hardware architecture (for example, [systemitem]``x86_64``).
@@ -44,7 +45,7 @@ Ensure that you choose the compatible parent channel for your packages.
 
 .Procedure: Create a software repository
 
-. In the {productname} {webui}, navigate to menu:Software[Manage Software Channels > Manage Repositories], and click btn:[Create Repository].
+. In the {productname} {webui}, navigate to menu:Software[Manage > Repositories], and click btn:[Create Repository].
 . On the [guimenu]``Create Repository`` page, give your repository a label (for example, [systemitem]``my-tools-sles12sp3-x86_64-repo``).
 . In the [guimenu]``Repository URL`` field, provide the path to the folder that contains the [path]``repodata`` file (for example, [systemitem]``file:///opt/mytools/``).
 You can use any valid addressing protocol in this field.
@@ -56,7 +57,7 @@ You can use any valid addressing protocol in this field.
 . Navigate to the [guimenu]``Sync`` tab and click btn:[Sync Now] to synchronize immediately.
 You can also set an automated synchronization schedule on this tab.
 
-.Procedure: Add cusatom channels to an activcation key
+.Procedure: Add custom channels to an activation key
 
 . In the {productname} {webui}, navigate to menu:Systems[Activation Keys], and select the key you want to add the custom channel to.
 . On the [guiemnu]``Details`` tab, in the [guimenu]``Child Channels`` field, select the channel to associate.
@@ -67,7 +68,13 @@ You can hold the btn:[Ctrl] key to select multiple channels, if you need to.
 
 == Delete Custom Channels
 
-TODO:: write this
+You cannot delete {productname} channels.
+Only custom channels can be deleted.
+
+. In the {productname} {webui}, navigate to menu:Software[Manage > Channels], and select the channel you want to delete.
+. Click btn:[Delete software channel].
+. On the [guimenu]``Delete Channel`` page, check the details of the channel you are deleting, and check the [guimenu]``Unsubscribe Systems`` checkbox to remove the custom channel from any systems that might still be subscribed.
+. Click btn:[Delete Channel].
 
 Note that when channels are deleted, the packages that are part of the deleted channel are not automatically removed.
 If you try to update packages that have had their channel deleted, it can cause errors.

--- a/modules/administration/pages/channel-management.adoc
+++ b/modules/administration/pages/channel-management.adoc
@@ -25,7 +25,7 @@ This section gives more detail on how to create, administer, and delete custom c
 If you have custom software packages that you need to install on your {productname} systems, you can create a custom child channel to manage them.
 You will need to create the channel in the {productname} {webui} and create a repository for the packages, before assigning the channel to your systems.
 
-Note that if you include a package tagged with [systemitem]``release`` in your channel, then it will be automatically installed when the channel is installed.
+Note that if you include a package with [systemitem]``-release`` at the end of the package name in your channel, it will be automatically installed when the channel is installed.
 
 [IMPORTANT]
 ====

--- a/modules/administration/pages/channel-management.adoc
+++ b/modules/administration/pages/channel-management.adoc
@@ -11,7 +11,9 @@ endif::[]
 
 Channels are a method of grouping software packages.
 
-In {productname}, channels are grouped into base and child channels, with base channels usually grouped by hardware architecture and software version, and child channels being related to a specific base channel.
+In {productname}, channels are grouped into base and child channels, with base channels grouped by operating system type, version, and architecture, and child channels being compatible with their related base channel.
+When a system has been assigned to a base channel, it is only possible for that system to install the related child channels.
+Organizing channels in this way ensures that only compatible packages are installed on each system.
 
 While {productname}  provides all required channels, you might find it useful to create custom channels specific to your environment.
 {productname} Administrators and Channel Administrators have channel management authority, which gives them the ability to create and manage their own custom channels.
@@ -20,13 +22,48 @@ This section gives more detail on how to create, administer, and delete custom c
 
 == Create Custom Channels
 
-TODO:: write this
+If you have custom software packages that you need to install on your {productname} systems, you can create a custom child channel to manage them.
+You will need to create the channel in the {productname} {webui} and create a repository for the packages, before assigning the channel to your systems.
 
 Note that if you include a package tagged with [systemitem]``release`` in your channel, then it will be automatically installed when the channel is installed.
 
-== Administer Custom Channels
+[IMPORTANT]
+====
+Do not create child channels containing packages that are not compatible with the client system.
+====
 
-TODO:: write this
+.Procedure: Create a custom channel
+
+. In the {productname} {webui}, navigate to menu:Software[Manage Software Channels], and click btn:[Create Channel].
+. On the [guimenu]``Create Software Channel`` page, give your channel a name (for example, [systemitem]``My Tools SLES 12 SP3 x86_64``) and a label (for example, [systemitem]``my-tools-sles12sp3-x86_64``).
+. In the [guimenu]``Parent Channel`` drop down, choose the relevant base channel (for example [systemitem]``SLES12-SP3-Pool for x86_64``).
+Ensure that you choose the compatible parent channel for your packages.
+. In the [guimenu]``Architecture`` drop down, choose the appropriate hardware architecture (for example, [systemitem]``x86_64``).
+. Provide any additional information in the contact details, channel access control, and GPG fields, as required for your environment.
+. Click btn:[Create Channel]
+
+.Procedure: Create a software repository
+
+. In the {productname} {webui}, navigate to menu:Software[Manage Software Channels > Manage Repositories], and click btn:[Create Repository].
+. On the [guimenu]``Create Repository`` page, give your repository a label (for example, [systemitem]``my-tools-sles12sp3-x86_64-repo``).
+. In the [guimenu]``Repository URL`` field, provide the path to the folder that contains the [path]``repodata`` file (for example, [systemitem]``file:///opt/mytools/``).
+You can use any valid addressing protocol in this field.
+. Uncheck the [guimenu]``Has Signed Metadata?`` check box.
+. Provide any additional information in the SSL fields, as required for your environment.
+. Click btn:[Create Repository]
+. Synchronize your new repository with your custom channel by navigating to menu:Software[Manage Software Channels > Overview], clicking on the name of your newly created custom channel, and navigating to the [guimenu]``Repositories`` tab.
+. Ensure the repository you want to synchronize is checked, and click btn:[Update Repositories].
+. Navigate to the [guimenu]``Sync`` tab and click btn:[Sync Now] to synchronize immediately.
+You can also set an automated synchronization schedule on this tab.
+
+.Procedure: Add cusatom channels to an activcation key
+
+. In the {productname} {webui}, navigate to menu:Systems[Activation Keys], and select the key you want to add the custom channel to.
+. On the [guiemnu]``Details`` tab, in the [guimenu]``Child Channels`` field, select the channel to associate.
+You can hold the btn:[Ctrl] key to select multiple channels, if you need to.
+. Click btn:[Update Activation Key].
+
+
 
 == Delete Custom Channels
 
@@ -35,3 +72,5 @@ TODO:: write this
 Note that when channels are deleted, the packages that are part of the deleted channel are not automatically removed.
 If you try to update packages that have had their channel deleted, it can cause errors.
 In this case, you will need to manually remove the packages.
+Packages can be manually removed in the {productname} {webui} by going to menu:Systems[Systems > All] and selecting the system, navigating to the menu:States[Packages] tab, and setting the package state to [guimenu]``Removed``.
+Note that removing the package using a command line package manager or the [guimenu]``Software`` menu will not permanently remove the package.

--- a/modules/architecture/pages/spacewalk-repo-sync.adoc
+++ b/modules/architecture/pages/spacewalk-repo-sync.adoc
@@ -31,7 +31,7 @@ Usage: spacewalk-repo-sync [options]
 
 Options:
   -h, --help            show this help message and exit
-  -l, --list            List the custom channels with the assosiated
+  -l, --list            List the custom channels with the associated
                         repositories.
   -s, --show-packages   List all packages in a specified channel.
   -u URL, --url=URL     The url of the repository. Can be used multiple times.

--- a/modules/client-configuration/nav-client-config-guide.adoc
+++ b/modules/client-configuration/nav-client-config-guide.adoc
@@ -5,6 +5,7 @@ ifndef::backend-pdf[]
 ** xref:clients-and-scc.adoc[SUSE Customer Center]
 ** xref:clients-and-activation-keys.adoc[Activation Keys]
 ** xref:traditional-vs-salt.adoc[Traditional VS Salt]
+** xref:channels.adoc[Channels]
 ** xref:bootstrapping-clients.adoc[Bootstrapping]
 ** xref:contact-methods.adoc[Client Contact Methods]
 // Registering Manually
@@ -98,7 +99,3 @@ include::modules/client-configuration/pages/disconnected-setup.adoc[leveloffset=
 include::modules/client-configuration/pages/subscription-management.adoc[leveloffset=+1]
 
 endif::[]
-
-
-
-

--- a/modules/client-configuration/pages/channels.adoc
+++ b/modules/client-configuration/pages/channels.adoc
@@ -1,0 +1,55 @@
+[[channels]]
+= Software Channels
+// Antora entities
+ifndef::backend-pdf[]
+include::ROOT:partial$entities.adoc[]
+endif::[]
+
+// PDF entities
+ifdef::backend-pdf[]
+include::_partials/entities.adoc[]
+endif::[]
+
+// Originally copied from reference-webui-channels.adoc. LKB 2019-03-11
+
+A software channel provides packages grouped by products or applications to simplify the selection of packages to be installed on a system.
+
+There are two types of software channels: base channels and child channels.
+
+Base Channels::
+A base channel consists of packages built for a specific architecture and release.
+For example, all of the packages in {sls}{nbsp}12 for the `x86_64` architecture make up a base channel.
+The list of packages in {sls}{nbsp}12 for the `s390x` architecture make up a different base channel.
++
+
+A system must be subscribed to only one base channel assigned automatically during registration based on the {sle} release and system architecture.
+For paid base channels, an associated subscription must exist.
+
+Child Channels::
+A child channel is associated with a base channel and provides extra packages.
+For example, an organization can create a child channel associated with {sls} on `x86_64` architecture that contains extra packages for a custom application.
++
+
+Especially important are the {productname} Tools channels that are available for every base channel.
+These tools channels provide the tools needed to connect the clients with the {productname} server.
++
+
+A system can be subscribed to multiple child channels of its base channel.
+Only packages provided by a subscribed channel can be installed or updated.
++
+
+[NOTE]
+====
+Do not create child channels containing packages that are not compatible with the client system.
+====
++
+
+In the {productname} {webui} you can browse your available channels by category: [guimenu]``All``, [guimenu]``SUSE``, [guimenu]``Channels``, [guimenu]``My Channels``, [guimenu]``Shared``, and [guimenu]``Retired``.
+
+== Custom Channels
+
+{productname} Administrators and Channel Administrators have channel management authority.
+This authority gives them the ability to create and manage their own custom channels.
+
+For more on creating custom channels, see the Administration Guide.
+// TODO:: fix xref

--- a/modules/client-configuration/pages/channels.adoc
+++ b/modules/client-configuration/pages/channels.adoc
@@ -12,44 +12,28 @@ endif::[]
 
 // Originally copied from reference-webui-channels.adoc. LKB 2019-03-11
 
-A software channel provides packages grouped by products or applications to simplify the selection of packages to be installed on a system.
+Channels are a method of grouping software packages.
+In {productname} channels are divided into base channels, and child channels.
+Organizing channels in this way ensures that only compatible packages are installed on each system.
 
-There are two types of software channels: base channels and child channels.
-
-Base Channels::
-A base channel consists of packages built for a specific architecture and release.
+A base channel consists of packages built for a specific operating system type, version, and architecture.
 For example, all of the packages in {sls}{nbsp}12 for the `x86_64` architecture make up a base channel.
 The list of packages in {sls}{nbsp}12 for the `s390x` architecture make up a different base channel.
-+
-
 A system must be subscribed to only one base channel assigned automatically during registration based on the {sle} release and system architecture.
 For paid base channels, an associated subscription must exist.
 
-Child Channels::
-A child channel is associated with a base channel and provides extra packages.
-For example, an organization can create a child channel associated with {sls} on `x86_64` architecture that contains extra packages for a custom application.
-+
-
-Especially important are the {productname} Tools channels that are available for every base channel.
-These tools channels provide the tools needed to connect the clients with the {productname} server.
-+
-
+A child channel is associated with a specific base channel and provides only packages that are compatible with that base channel.
 A system can be subscribed to multiple child channels of its base channel.
-Only packages provided by a subscribed channel can be installed or updated.
-+
+When a system has been assigned to a base channel, it is only possible for that system to install the related child channels.
+For example, if a system has been assigned to the {sls}{nbsp}12 `x86_64` base channel, they will only be able to install or update packages compatible with {sls}{nbsp}12 `x86_64`.
 
-[NOTE]
-====
-Do not create child channels containing packages that are not compatible with the client system.
-====
-+
-
-In the {productname} {webui} you can browse your available channels by category: [guimenu]``All``, [guimenu]``SUSE``, [guimenu]``Channels``, [guimenu]``My Channels``, [guimenu]``Shared``, and [guimenu]``Retired``.
+In the {productname} {webui} you can browse your available channels by navigating to menu:Software[Channels].
+You can modify or create new channels by navigating to menu:Software[Manage Software Channels].
 
 == Custom Channels
 
-{productname} Administrators and Channel Administrators have channel management authority.
-This authority gives them the ability to create and manage their own custom channels.
+If you require packages that are not provided by the standard {productname} base channels, you can create custom channels.
+{productname} Administrators and Channel Administrators have channel management authority, which gives them the ability to create and manage their own custom channels.
 
 For more on creating custom channels, see the Administration Guide.
 // TODO:: fix xref

--- a/modules/client-configuration/pages/channels.adoc
+++ b/modules/client-configuration/pages/channels.adoc
@@ -20,7 +20,7 @@ A base channel consists of packages built for a specific operating system type, 
 For example, all of the packages in {sls}{nbsp}12 for the `x86_64` architecture make up a base channel.
 The list of packages in {sls}{nbsp}12 for the `s390x` architecture make up a different base channel.
 A system must be subscribed to only one base channel assigned automatically during registration based on the {sle} release and system architecture.
-For paid base channels, an associated subscription must exist.
+For paid channels provided by a vendor, you must have an associated subscription.
 
 A child channel is associated with a specific base channel and provides only packages that are compatible with that base channel.
 A system can be subscribed to multiple child channels of its base channel.


### PR DESCRIPTION
(This relates to https://bugzilla.novell.com/show_bug.cgi?id=1124634 but is broader than just that bug.)

* Added Channels section to client config, cribbed from reference-webui-channels.adoc, with reference to Admin Guide
* Added Channels section to Admin Guide, with outline for the section, and content from BZ1124634

Todo:

- [ ] Complete writing sections in Admin Guide