### PR TITLE
Remove Ubuntu trust GPG key section

### DIFF
--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -61,19 +61,6 @@ This section describes how to manually prepare {ubuntu} clients for registration
 deb https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/debian/xUbuntu_16.04/ /
 ----
 +
-. From the command line, import the appropriate release key and add it to the keyring:
-+
-----
-curl https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/debian/xUbuntu_16.04/Release.key
-sudo apt-key add -
-----
-+
-. Update the repository list in the package manager:
-+
-----
-sudo apt update
-----
-+
 . Edit the [filename]``sudoers`` file:
 +
 ----
@@ -92,19 +79,6 @@ Grant [command]``sudo`` access to the user by adding this line to the [filename]
 +
 ----
 deb https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/debian/xUbuntu_18.04/ /
-----
-+
-. From the command line, import the appropriate release key and add it to the keyring:
-+
-----
-curl https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/debian/xUbuntu_18.04/Release.key
-sudo apt-key add -
-----
-+
-. Update the repository list in the package manager:
-+
-----
-sudo apt update
 ----
 +
 . Edit the [filename]``sudoers`` file:


### PR DESCRIPTION
Remove Ubuntu trust GPG key instructions, which are handled automatically by SUSE Manager