### PR TITLE
Fix versions for SLE/openSUSE/salt

### DIFF
--- a/branding/pdf-resources/entities.adoc
+++ b/branding/pdf-resources/entities.adoc
@@ -16,16 +16,16 @@
 :susemgr: SUSE Manager
 :smr: SUSE Manager for Retail
 :uyuni: Uyuni
-:smrproductnumber: 3.2
+:smrproductnumber: 4.0
 :slepos: SUSE Linux Enterprise Point of Service
 :susemgrproxy: SUSE Manager Proxy
 :productnumber: 4.0
 :docversion: 4.0
-:saltversion: 2018.3.0
+:saltversion: 2019.2.0
 :webui: Web UI
-:sles-version: 12
-:sp-version: SP3
-:sp-version-l: sp3
+:sles-version: 15
+:sp-version: SP1
+:sp-version-l: sp1
 :jeos: JeOS
 :scc: SUSE Customer Center
 :sls: SUSE Linux Enterprise Server

--- a/suma-site.yml
+++ b/suma-site.yml
@@ -11,11 +11,11 @@ asciidoc:
     productname: 'SUSE Manager'
     productnumber: 4.0
     docversion: 4.0
-    saltversion: 2018.3.0
-    sles-version: 12
-    sp-version: SP3
-    sp-version-l: sp3
-    smrproductnumber: 3.2
+    saltversion: 2019.2.0
+    sles-version: 15
+    sp-version: SP1
+    sp-version-l: sp1
+    smrproductnumber: 4.0
 
     # Asciidoc Configuration Attributes
     linkattrs: true

--- a/uyuni-site.yml
+++ b/uyuni-site.yml
@@ -11,11 +11,11 @@ asciidoc:
     productname: 'Uyuni'
     productnumber: 4.0
     docversion: 4.0
-    saltversion: 2018.3.0
-    sles-version: 12
-    sp-version: SP3
-    sp-version-l: sp3
-    smrproductnumber: 3.2
+    saltversion: 2019.2.0
+    sles-version: 15
+    sp-version: 0
+    sp-version-l: 0
+    smrproductnumber: 4.0
 
     # Asciidoc Configuration Attributes
     linkattrs: true


### PR DESCRIPTION
Required for Beta3:

This is adjusting versioning, as we still have 3.2 and SLE12 SP3 and salt 2018.03.0.