### PR TITLE
Added new troubleshooting section for reclaiming disk space

### DIFF
--- a/modules/administration/nav-administration-guide.adoc
+++ b/modules/administration/nav-administration-guide.adoc
@@ -36,6 +36,7 @@ ifndef::backend-pdf[]
 *** xref:content-lifecycle.adoc[Content Lifecycle Management]
 ** Troubleshooting
 *** xref:tshoot-corruptrepo.adoc[Troubleshooting Corrupt Repositories]
+*** xref:tshoot-diskspace.adoc[Troubleshooting Disk Space]
 *** xref:tshoot-localcert.adoc[Troubleshooting Local Certificates]
 *** xref:tshoot-osadjabberd.adoc[Troubleshooting OSAD and jabberd]
 *** xref:tshoot-packages.adoc[Troubleshooting Packages]
@@ -114,6 +115,8 @@ include::modules/administration/pages/content-lifecycle.adoc[leveloffset=+2]
 == Troubleshooting
 
 include::modules/administration/pages/tshoot-corruptrepo.adoc[leveloffset=+2]
+
+include::modules/administration/pages/tshoot-diskspace.adoc[leveloffset=+2]
 
 include::modules/administration/pages/tshoot-localcert.adoc[leveloffset=+2]
 

--- a/modules/administration/pages/tshoot-diskspace.adoc
+++ b/modules/administration/pages/tshoot-diskspace.adoc
@@ -1,0 +1,8 @@
+[[troubleshooting-disk-space]]
+= Troubleshooting Disk Space
+
+
+If you need to reclaim more disk space, try these suggestions:
+
+* Remove custom channels (you cannot remove official SUSE channels)
+* Use the [command]``spacewalk-data-fsck --help`` command to compare the spacewalk database to the filesystem and remove entries if either is missing.

--- a/modules/administration/pages/tshoot-diskspace.adoc
+++ b/modules/administration/pages/tshoot-diskspace.adoc
@@ -5,7 +5,7 @@ When you prepare to install {productname}, you need to be careful that you allow
 Running out of disk space can have a severe impact on the {productname} database and file structure which, in most cases, is not recoverable.
 You will need to carefully monitor the  amount of disk space you have  available on your systems to prevent this from happening.
 
-If you notice disk space is running low, reclaim space before it runs too low with these suggestions.
+If you notice disk space is running low, you can reclaim it with these suggestions.
 
 
 

--- a/modules/administration/pages/tshoot-diskspace.adoc
+++ b/modules/administration/pages/tshoot-diskspace.adoc
@@ -1,8 +1,20 @@
 [[troubleshooting-disk-space]]
 = Troubleshooting Disk Space
 
+When you prepare to install {productname}, you need to be careful that you allow  enough disk space.
+Running out of disk space can have a severe impact on the {productname} database and file structure which, in most cases, is not recoverable.
+You will need to carefully monitor the  amount of disk space you have  available on your systems to prevent this from happening.
 
-If you need to reclaim more disk space, try these suggestions:
+If you notice disk space is running low, reclaim space before it runs too low with these suggestions.
 
-* Remove custom channels (you cannot remove official SUSE channels)
-* Use the [command]``spacewalk-data-fsck --help`` command to compare the spacewalk database to the filesystem and remove entries if either is missing.
+
+
+== Unused Custom Channels
+
+You cannot remove official SUSE channels, but if you have set up custom channels that you are no longer using, you can delete them to reclaim disk space.
+
+
+
+== Redundant Database Entries
+
+Use the [command]``spacewalk-data-fsck --help`` command to list the options for working with the database, and deleting any  orphaned database entries.


### PR DESCRIPTION
I removed a section about reclaiming disk space from the zsystems chapter in the install guide (https://github.com/SUSE/doc-susemanager/pull/435), which would fit better in the Admin Guide. Will need some tidying up yet.