### PR TITLE
Add notes about bandwidth usage at registration time

### DIFF
--- a/modules/client-configuration/pages/creating-activation-keys.adoc
+++ b/modules/client-configuration/pages/creating-activation-keys.adoc
@@ -52,4 +52,7 @@ You will also need less manual interaction with your system after registration.
 Consider a naming scheme for your activation keys to help you keep track of them.
 * Note that the [guimenu]``Configuration File Deployment`` check box does not appear until after you have created the activation key.
 Ensure you go back and check the box if you need to enable configuration management.
-
+* In environments where bandwidth is constrained, keep in mind Activation Keys might result in automatic downloading of software at registration time, which might not be desirable. In particular:
+** assigning a SUSE Product Pool channel will result in the automatic installation of the corresponding product descriptor package,
+** any package in the [guimenu]``Packages`` section will be installed and
+** any Salt state from the [guimenu]``Configuration`` section might trigger downloads depending on its contents.


### PR DESCRIPTION
Adding some notes on bandwitdh usage during registration depending on the Activation Key.

General context: https://github.com/SUSE/spacewalk/wiki/Proxy-NG-research