### PR TITLE
Minion id is visible in System Info box

### DIFF
--- a/adoc/reference-webui-systems.adoc
+++ b/adoc/reference-webui-systems.adoc
@@ -403,6 +403,9 @@ The IP address of the client.
 IPv6 Address:::
 The IPv6 address of the client.
 
+Minion Id:::
+On salt clients only, shows the minion identification value.
+
 Virtualization:::
 If the client is a virtual machine, the type of virtualization is listed.
 


### PR DESCRIPTION
See https://github.com/SUSE/spacewalk/pull/7714

It is a backport of https://github.com/SUSE/doc-susemanager/pull/438 for SUSE Manager 3.2