### PR TITLE
Add Leap 15.1, Ubuntu 16.04 and 18.04 as supported salt clients

### DIFF
--- a/modules/installation/pages/client-requirements.adoc
+++ b/modules/installation/pages/client-requirements.adoc
@@ -17,6 +17,9 @@ Supported operating systems for traditional and Salt clients are listed in this 
 |_Latest minor release {rhnminrelease6}_               | {x86}, {x86}_64                              | Supported           | Supported
 |_Latest minor release {rhnminrelease7}_               | {x86}_64                                     | Supported           | Supported
 | Open Enterprise Server 2015, 2015 SP1, 2018          | {x86}_64                                     | Supported           | Supported
+| {opensuse} Leap 15.1                                 | {x86}_64                                     | Unsupported         | Supported
+| {ubuntu} 16.04                                       | {x86}_64                                     | Unsupported         | Supported
+| {ubuntu} 18.04                                       | {x86}_64                                     | Unsupported         | Supported
 |===
 
 

--- a/suma-site.yml
+++ b/suma-site.yml
@@ -39,6 +39,7 @@ asciidoc:
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
     rhnminrelease7: 'Red Hat Enterprise Linux Server 7'
     ubuntu: Ubuntu
+    opensuse: openSUSE
     kickstart: Kickstart
     susemgr: 'SUSE Manager'
     productproxy: '{productname} Proxy'

--- a/uyuni-site.yml
+++ b/uyuni-site.yml
@@ -39,6 +39,7 @@ asciidoc:
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
     rhnminrelease7: 'Red Hat Enterprise Linux Server 7'
     ubuntu: Ubuntu
+    opensuse: openSUSE
     kickstart: Kickstart
     susemgr: 'SUSE Manager'
     productproxy: '{productname} Proxy'


### PR DESCRIPTION
Unless I am wrong, SUSE Manager 4.0 will support:
- openSUSE Leap 15.1
- Ubuntu 16.04
- Ubuntu 18.04

only as salt clients.

Maybe this section should have alternatives for Uyuni, as there we support Leap 42.3 as well, and CentOS6 and 7, but not RHEL6/7.