### PR TITLE
Virtualization: mention the minimum salt version

### DIFF
--- a/modules/administration/pages/virtualization.adoc
+++ b/modules/administration/pages/virtualization.adoc
@@ -331,6 +331,7 @@ If the {vmhost} is registered as a Salt minion, a final configuration step is ne
 . From the menu:System Details[Properties] page, enable the [guimenu]``Add-on System Type`` ``Virtualization Host`` and confirm with btn:[Update Properties].
 . Schedule a Hardware Refresh. On the menu:System Details[Hardware] page click btn:[Schedule Hardware Refresh].
 
+Salt 2019.2.0 or later is required on the virtual host in order for the salt-based virtualization features to fully work on it.
 
 [[sec.virtualization.autoinstall.req_vmhost.traditional]]
 ==== {vmhost} setup on Traditional clients


### PR DESCRIPTION
Tell that the virtualization features will only work if the salt minion has 2019.2.0+ salt