### PR TITLE
Tuning: suggest disabling non-essential Taskomatic jobs

### DIFF
--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -88,7 +88,8 @@ Keep the server monitored in order to identify possible issues early.
 Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 ** Disable hourly synchronization of Cobbler files. 
 Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
-** Disable daily run of Gatherer and Subscription Matcher. Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+** Disable daily run of Gatherer and Subscription Matcher. 
+Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 
 Note that increasing the number of Postgres connections will require more RAM, make sure the {productname} server is monitored and swap is never used.
 

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -85,7 +85,7 @@ Keep the server monitored in order to identify possible issues early.
 * Increase the maximum heap memory for the search daemon to be able to index many minions. Set 4 GiB instead of the current default 512 MB: add [parameter]``rhn-search.java.maxmemory=4096`` in [path]``/etc/rhn/rhn.conf`` (affects background indexing only).
 * Consider disabling Taskomatic jobs, especially if the provided functionality is not used:
 ** Disable daily comparison of configuration files. 
-Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+Click menu:Admin[Task Schedules], then the btn:[compare-configs-default] link, then the btn:[Disable Schedule] button and finally btn:[Delete Schedule].
 ** Disable hourly synchronization of Cobbler files. 
 Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 ** Disable daily run of Gatherer and Subscription Matcher. 

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -89,7 +89,7 @@ Click menu:Admin[Task Schedules], then the btn:[compare-configs-default] link, t
 ** Disable hourly synchronization of Cobbler files. 
 Click menu:Admin[Task Schedules], then the btn:[cobbler-sync-default] link, then the btn:[Disable Schedule] button and finally btn:[Delete Schedule].
 ** Disable daily run of Gatherer and Subscription Matcher. 
-Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+Click menu:Admin[Task Schedules], then the btn:[gatherer-matcher-default] link, then the btn:[Disable Schedule] button and finally btn:[Delete Schedule].
 
 Note that increasing the number of Postgres connections will require more RAM, make sure the {productname} server is monitored and swap is never used.
 

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -86,7 +86,8 @@ Keep the server monitored in order to identify possible issues early.
 * Consider disabling Taskomatic jobs, especially if the provided functionality is not used:
 ** Disable daily comparison of configuration files. 
 Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
-** Disable hourly synchronization of Cobbler files. Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+** Disable hourly synchronization of Cobbler files. 
+Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 ** Disable daily run of Gatherer and Subscription Matcher. Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 
 Note that increasing the number of Postgres connections will require more RAM, make sure the {productname} server is monitored and swap is never used.

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -87,7 +87,7 @@ Keep the server monitored in order to identify possible issues early.
 ** Disable daily comparison of configuration files. 
 Click menu:Admin[Task Schedules], then the btn:[compare-configs-default] link, then the btn:[Disable Schedule] button and finally btn:[Delete Schedule].
 ** Disable hourly synchronization of Cobbler files. 
-Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+Click menu:Admin[Task Schedules], then the btn:[cobbler-sync-default] link, then the btn:[Disable Schedule] button and finally btn:[Delete Schedule].
 ** Disable daily run of Gatherer and Subscription Matcher. 
 Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -91,6 +91,6 @@ Click menu:Admin[Task Schedules], then the btn:[cobbler-sync-default] link, then
 ** Disable daily run of Gatherer and Subscription Matcher. 
 Click menu:Admin[Task Schedules], then the btn:[gatherer-matcher-default] link, then the btn:[Disable Schedule] button and finally btn:[Delete Schedule].
 
-Note that increasing the number of Postgres connections will require more RAM, make sure the {productname} server is monitored and swap is never used.
+Note that increasing the number of PostgreSQL connections will require more RAM, make sure the {productname} server is monitored and swap is never used.
 
 Also note the above settings should be regarded as guidelines{mdash}they have been tested to be safe but care should be exercised when changing them, and consulting support is highly recommended.

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -86,6 +86,7 @@ Keep the server monitored in order to identify possible issues early.
 * Consider disabling Taskomatic jobs, especially if the provided functionality is not used:
 ** Disable daily comparison of configuration files. Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 ** Disable hourly synchronization of Cobbler files. Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+** Disable daily run of Gatherer and Subscription Matcher. Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 
 Note that increasing the number of Postgres connections will require more RAM, make sure the {productname} server is monitored and swap is never used.
 

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -82,8 +82,10 @@ Keep the server monitored in order to identify possible issues early.
 * Increase the number of Salt master workers so that more requests can run in parallel (otherwise Tomcat and Taskomatic workers will starve waiting for the Salt API, and Salt will not be able to serve files timely). Set parameter [parameter]``worker_threads: 100`` in [path]``/etc/salt/master.d/susemanager.conf`` (affects onboarding and patching).
 ** Increase this parameter further if file management states fail with the error "Unable to manage file: Message timed out"
 ** Note that Salt master workers can consume significant amounts of RAM (typically about 70{nbsp}MB per worker). It is recommended to keep usage monitored when increasing this value and to do so in relatively small increments (eg. 20) until failures are no longer produced.
-* Disable daily comparison of configuration files. Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 * Increase the maximum heap memory for the search daemon to be able to index many minions. Set 4 GiB instead of the current default 512 MB: add [parameter]``rhn-search.java.maxmemory=4096`` in [path]``/etc/rhn/rhn.conf`` (affects background indexing only).
+* Consider disabling Taskomatic jobs, especially if the provided functionality is not used:
+** Disable daily comparison of configuration files. Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+** Disable hourly synchronization of Cobbler files. Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 
 Note that increasing the number of Postgres connections will require more RAM, make sure the {productname} server is monitored and swap is never used.
 

--- a/modules/administration/pages/tuning-largedeploys.adoc
+++ b/modules/administration/pages/tuning-largedeploys.adoc
@@ -84,7 +84,8 @@ Keep the server monitored in order to identify possible issues early.
 ** Note that Salt master workers can consume significant amounts of RAM (typically about 70{nbsp}MB per worker). It is recommended to keep usage monitored when increasing this value and to do so in relatively small increments (eg. 20) until failures are no longer produced.
 * Increase the maximum heap memory for the search daemon to be able to index many minions. Set 4 GiB instead of the current default 512 MB: add [parameter]``rhn-search.java.maxmemory=4096`` in [path]``/etc/rhn/rhn.conf`` (affects background indexing only).
 * Consider disabling Taskomatic jobs, especially if the provided functionality is not used:
-** Disable daily comparison of configuration files. Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
+** Disable daily comparison of configuration files. 
+Click on menu:Admin[Task Schedules], then on the btn:[compare-configs-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 ** Disable hourly synchronization of Cobbler files. Click on menu:Admin[Task Schedules], then on the btn:[cobbler-sync-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 ** Disable daily run of Gatherer and Subscription Matcher. Click on menu:Admin[Task Schedules], then on the btn:[gatherer-matcher-default] link, then on the btn:[Disable Schedule] button and finally on btn:[Delete Schedule].
 


### PR DESCRIPTION
Suggestion emerged as part of the resolution of the following SUSE Manager bugs:

https://bugzilla.suse.com/show_bug.cgi?id=1135075#c3
https://bugzilla.suse.com/show_bug.cgi?id=1135025

In essence, this jobs ran for hours/exhausted RAM while users were not interested in respective features, so it's best to just recommend disabling them.