### PR TITLE
Reference Guide component from PR#344

### DIFF
--- a/modules/reference/pages/systems/system-details/sd-virtualization.adoc
+++ b/modules/reference/pages/systems/system-details/sd-virtualization.adoc
@@ -108,7 +108,7 @@ This password is the Spice or VNC one.
 
 // TODO Add a screenshot of the graphical console
 
-For the Spice display to be adjusted to the window, the spice VD agent needs to be installed within the virtual machine.
+For the Spice display to be adjusted to the window, the Spice VD agent needs to be installed within the virtual machine.
 
 
 [[sd-virtualization-deployment-management]]

--- a/modules/reference/pages/systems/system-details/sd-virtualization.adoc
+++ b/modules/reference/pages/systems/system-details/sd-virtualization.adoc
@@ -101,7 +101,7 @@ The new virtual machine will start immediately after it has been defined.
 
 [float]
 [[sdc-virt-host-guest-graphical-console]]
-===== Display a virtual machine graphical console[Salt]
+===== Display a virtual machine graphical console [Salt]
 
 The virtual machine graphical console might prompt you for a password.
 This password is the Spice or VNC one.

--- a/modules/reference/pages/systems/system-details/sd-virtualization.adoc
+++ b/modules/reference/pages/systems/system-details/sd-virtualization.adoc
@@ -41,6 +41,8 @@ This field contains the possible actions for the guest.
 These are depending on the virtual guest status, they may not refresh instantaneously when running a Start, Stop, Suspend, Resume action.
 The btn:[Edit] button allows changing virtual guest properties, including the amount of allocated memory and virtual CPUs.
 
+The btn:[Graphical Console] button opens the Spice or VNC display in a new tab.
+
 If you have System Group Administrator responsibilities assigned for your guest systems, a user might see the message [guimenu]``You do not have permission to access this system`` in the table.
 This is because it is possible to assign virtual guests on a single host to multiple System Group Administrators.
 Only users that have System Group Administrator privileges on the host system may create new virtual guests.
@@ -95,6 +97,19 @@ By default a disk and a network interfaces are added. The only required value to
 The new virtual machine will start immediately after it has been defined.
 
 // TODO Add a screenshot of the create page showing the additional fields
+
+
+[float]
+[[sdc-virt-host-guest-graphical-console]]
+===== Display a virtual machine graphical console[Salt]
+
+The virtual machine graphical console might prompt you for a password.
+This password is the Spice or VNC one.
+
+// TODO Add a screenshot of the graphical console
+
+For the Spice display to be adjusted to the window, the spice VD agent needs to be installed within the virtual machine.
+
 
 [[sd-virtualization-deployment-management]]
 == Deployment [Management]


### PR DESCRIPTION
https://github.com/SUSE/spacewalk/issues/7541
https://github.com/SUSE/doc-susemanager/pull/344

> This PR got caught up in the IA lift 'n' shift. The documentation for the AT Guide/Client Cfg has been completed, we are waiting for the appropriate section in the Reference Guide to be migrated, so that that content can also be replicated (ping @jcayouette).