### PR TITLE
Remove wrong label

### DIFF
--- a/modules/reference/pages/navigation/categories-and-pages.adoc
+++ b/modules/reference/pages/navigation/categories-and-pages.adoc
@@ -138,7 +138,7 @@ Clone patches for an organization for ease of replication and distribution acros
 
 View and manage the available {productname} channels and the files they contain.
 
-menu:Main Menu[Channel List]::
+menu:Channel List[]::
 View a list of all software channels and those applicable to your systems.
 
 menu:Package Search[]::
@@ -254,5 +254,5 @@ Display the log entries of the Tomcat server, on which the {productname} server 
 List references to available help resources such as the product documentation, release notes, and a general search for all of this.
 
 
-menu:Main Menu[External Links]::
+menu:External Links[]::
 List external links to the knowledge base and the online documentation.


### PR DESCRIPTION
Remove `Main Menu` placeholder.

The problem:
![Screenshot from 2019-06-06 16-05-44](https://user-images.githubusercontent.com/7080830/59040650-6b0cd680-8877-11e9-8cc8-98710b8afc69.png)
