### PR TITLE
Minion needs to be restarted after bootstrap

### DIFF
--- a/modules/administration/pages/virtualization.adoc
+++ b/modules/administration/pages/virtualization.adoc
@@ -315,6 +315,10 @@ Apart from being able to serve as a host for {kvm} or {xen} guests, which are ma
 ** Execute the bootstrap script to register the {vmhost}.
 +
 
+[IMPORTANT]
+====
+After bootstrap, Salt minions need to be restarted in order to get instant virtual machines changes reflected in {productname}.
+====
 
 [[sec.virtualization.autoinstall.req_vmhost.salt]]
 ==== {vmhost} setup on Salt clients

--- a/modules/administration/pages/virtualization.adoc
+++ b/modules/administration/pages/virtualization.adoc
@@ -317,7 +317,7 @@ Apart from being able to serve as a host for {kvm} or {xen} guests, which are ma
 
 [IMPORTANT]
 ====
-After bootstrap, Salt minions need to be restarted in order to get instant virtual machines changes reflected in {productname}.
+Salt minions must be restarted after enabling the Virtualization Host entitlement in order for instant virtual machine changes to be reflected.
 ====
 
 [[sec.virtualization.autoinstall.req_vmhost.salt]]

--- a/modules/administration/pages/virtualization.adoc
+++ b/modules/administration/pages/virtualization.adoc
@@ -317,7 +317,7 @@ Apart from being able to serve as a host for {kvm} or {xen} guests, which are ma
 
 [IMPORTANT]
 ====
-Salt minions must be restarted after enabling the Virtualization Host entitlement in order for instant virtual machine changes to be reflected.
+Salt minions must be restarted after enabling the Virtualization Host entitlement in order to see virtual machine changes in {productname} instantly.
 ====
 
 [[sec.virtualization.autoinstall.req_vmhost.salt]]


### PR DESCRIPTION
We need to mention that a restart of a minion is needed in order to make virtualization fully work.

We were restarting automatically but that can cause some other issues. Related PR which change that behavior is https://github.com/SUSE/spacewalk/pull/8083

