### PR TITLE
Disable section about using spacewalk-common-channels with Ubuntu

### DIFF
--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -119,6 +119,8 @@ mgr-create-bootstrap-repo --with-custom-channels
 
 For more information on creating custom repositories, see xref:administration:channel-management.adoc[].
 
+////
+// To be enabled once spacewalk-utils support status is clarified
 .Procedure: Preparing to Register {ubuntu} Clients with Spacewalk
 
 Before you begin, ensure you have installed the `spacewalk-common-channels` utility from the `spacewalk-utils` package.
@@ -177,6 +179,7 @@ Ensure you use the appropriate version number in this command, either [systemite
 ----
 spacewalk-common-channels -u <admin_user> -p <admin_pass> -a amd64-deb -v 'ubuntu-1804*'
 ----
+////
 . Synchronize the new custom channels.
 You can check the progress of your synchronization from the command line with this command:
 +


### PR DESCRIPTION
`spacewalk-common-channels` is part of the `spacewalk-utils` package. The support status for this packages needs to be clarified.
Until it gets clarified disable the section about using `spacewalk-common-channels` with Ubuntu.