### PR TITLE
4.0 - Document 8050 port opening

### DIFF
--- a/modules/administration/pages/virtualization.adoc
+++ b/modules/administration/pages/virtualization.adoc
@@ -481,5 +481,6 @@ btn:[Confirm] the action on the displayed popup dialog.
 === Displaying {vmguest} graphical console
 
 In order to be able to display a {vmguest} VNC or Spice graphical console, the virtual host corresponding port needs to be reachable by the server.
+The server's 8050 port also needs to be reachable.
 The {vmguest} graphics settings also have to listen on at least the virtual host address.
 This is the default for any {vmguest} created using the web interface.

--- a/modules/installation/pages/ports.adoc
+++ b/modules/installation/pages/ports.adoc
@@ -82,6 +82,11 @@ TCP
 
 For cobbler.
 
+8050::
+Inbound / TCP / websockify
+
+Needed to access graphical console of virtual machines from {productname} web interface.
+
 .Internally Used Ports on {productname} Server
 2828::
 Internal /


### PR DESCRIPTION
The VM Graphical Console feature requires the port 8050 to be reachable from the browser. Document this.

Port of #538.