### PR TITLE
some syntax fixes and fix complex ssh commands

### DIFF
--- a/modules/client-configuration/pages/contact-methods.adoc
+++ b/modules/client-configuration/pages/contact-methods.adoc
@@ -139,7 +139,7 @@ ssh_push_use_hostname = true
 
 It is also possible to adjust the number of threads to use for opening client connections in parallel.
 By default two parallel threads are used.
-Set [systemitem]``taskomatic.ssh_push_workers`` in [path]``/etc/rhn/rhn.conf`` like this:
+Set [systemitem]``taskomatic.ssh_push_workers`` in [path]``/etc/rhn/rhn.conf``:
 
 ----
 taskomatic.ssh_push_workers = number

--- a/modules/client-configuration/pages/contact-methods.adoc
+++ b/modules/client-configuration/pages/contact-methods.adoc
@@ -67,7 +67,7 @@ The {productname} daemon can be configured by editing the file on the client:
 
 This is the configuration file the rhnsd initialization script uses.
 An important parameter for the daemon is its check-in frequency.
-The default interval time is four hours (240 minutes).
+The default interval time is four hours (240 minutes).
 If you modify the configuration file, you must as {rootuser} restart the daemon with:
 
 ----
@@ -121,13 +121,12 @@ image::sshpush-taigon.png[scaledwidth=80%]
 === Configuring the Server for Push via SSH
 
 
-For tunneling connections via SSH, two available port numbers are required, one for tunneling HTTP and the second for tunneling via HTTPS (HTTP is only necessary during the registration process). The port numbers used by default are `1232` and ``1233``.
-To overwrite these, add two custom port numbers greater than 1024 to [path]``/etc/rhn/rhn.conf``
- like this:
+For tunneling connections via SSH, two available port numbers are required, one for tunneling HTTP and the second for tunneling via HTTPS (HTTP is only necessary during the registration process). The port numbers used by default are `1232` and `1233`.
+To overwrite these, add two custom port numbers greater than 1024 to [path]``/etc/rhn/rhn.conf`` like this:
 
 ----
-ssh_push_port_http = high port 1
-ssh_push_port_https = high port 2
+ssh_push_port_http = high_port_1
+ssh_push_port_https = high_port_2
 ----
 
 
@@ -140,9 +139,7 @@ ssh_push_use_hostname = true
 
 It is also possible to adjust the number of threads to use for opening client connections in parallel.
 By default two parallel threads are used.
-Set [systemitem]``taskomatic.ssh_push_workers``
- in [path]``/etc/rhn/rhn.conf``
- like this:
+Set [systemitem]``taskomatic.ssh_push_workers`` in [path]``/etc/rhn/rhn.conf`` like this:
 
 ----
 taskomatic.ssh_push_workers = number
@@ -152,27 +149,24 @@ taskomatic.ssh_push_workers = number
 === Using sudo with Push via SSH
 
 
-For security reasons you may desire to use sudo and SSH into a system as a user other than {rootuser}
-.
+For security reasons you may desire to use sudo and SSH into a system as a user other than {rootuser}.
 The following procedure will guide you through configuring sudo for use with Push via SSH.
 
 .sudo Requirements
 [NOTE]
 ====
-The packages [path]``spacewalk-taskomatic >= 2.1.165.19``
- and [path]``spacewalk-certs-tools => 2.1.6.7``
- are required for using sudo with Push via SSH.
+The packages [path]``spacewalk-taskomatic >= 2.1.165.19`` and [path]``spacewalk-certs-tools => 2.1.6.7`` are required for using sudo with Push via SSH.
 ====
 
 [[pro.bp.contact.methods.ssh.push.sudo]]
 .Procedure: Configuring sudo
 
 [[pro.bp.contact.methods.ssh.push.sudo.user]]
-. Set the following parameter on the server located in [path]``/etc/rhn/rhn.conf`` .
+. Set the following parameter on the server located in [path]``/etc/rhn/rhn.conf``.
 +
 
 ----
-ssh_push_sudo_user =`user`
+ssh_push_sudo_user = <user>
 ----
 +
 The server will use sudo to ssh as the configured [replaceable]``user``.
@@ -217,23 +211,19 @@ Clients already registered before changing the port numbers must be registered a
 .[command]``mgr-ssh-push-init`` Disables rhnsd
 [NOTE]
 ====
-The [command]``mgr-ssh-push-init`` command disables the [systemitem]``rhnsd``
- daemon which normally checks for updates every 4 hours.
-Because your clients cannot reach the server without using the Push via SSH contact method, the [systemitem]``rhnsd``
- daemon is disabled.
+The [command]``mgr-ssh-push-init`` command disables the [systemitem]``rhnsd`` daemon which normally checks for updates every 4 hours.
+Because your clients cannot reach the server without using the Push via SSH contact method, the [systemitem]``rhnsd`` daemon is disabled.
 ====
 
 
 For registration of systems which should be managed via the Push via SSH tunnel contact method, it is required to use an activation key that is configured to use this method.
-Normal [systemitem]``Push via SSH``
- is unable to reach the server.
+Normal [systemitem]``Push via SSH`` is unable to reach the server.
 For managing activation keys, see <<bp.key.managment>>.
 
-Run the following command as {rootuser}
-on the server to register a client:
+Run the following command as {rootuser} on the server to register a client:
 
 ----
-# mgr-ssh-push-init --client client --register \
+# mgr-ssh-push-init --client <client> --register \
 /srv/www/htdocs/pub/bootstrap/bootstrap_script --tunnel
 ----
 
@@ -242,7 +232,7 @@ To enable a client to be managed using Push via SSH (without tunneling), the sam
 Registration is optional since it can also be done from within the client in this case. [command]``mgr-ssh-push-init`` will also automatically generate the necessary SSH key pair if it does not yet exist on the server:
 
 ----
-# mgr-ssh-push-init --client`client`--register bootstrap_script
+# mgr-ssh-push-init --client <client> --register bootstrap_script
 ----
 
 
@@ -251,7 +241,8 @@ Tools like [command]``mgr_check`` and [command]``zypper`` will need an active SS
 To verify the Push via SSH tunnel connection manually, run the following command on the {productname} server:
 
 ----
-# ssh -i /root/.ssh/id_susemanager -R high port: susemanager :443`client`zypper ref
+# ssh -i /root/.ssh/id_susemanager -R <high_port>:<susemanager>:443 \
+<client> zypper ref
 ----
 
 [[bp.contact.methods.ssh.push.api.support]]
@@ -276,10 +267,9 @@ client.system.setDetails(key, 1000012345, {'contact_method' : 'ssh-push'})
 .Migration and Management via Push via SSH
 [NOTE]
 ====
-When a system should be migrated and managed using Push via SSH, it requires setup using the [systemitem]``mgr-ssh-push-init``
- script before the server can connect via SSH.
-This separate command requires human interaction to install the server's SSH key onto the managed client ({rootuser}
- password). The following procedure illustrates how to migrate an already registered system:
+When a system should be migrated and managed using Push via SSH, it requires setup using the [systemitem]``mgr-ssh-push-init`` script before the server can connect via SSH.
+This separate command requires human interaction to install the server's SSH key onto the managed client ({rootuser} password).
+The following procedure illustrates how to migrate an already registered system:
 ====
 
 .Procedure: Migrating Registered Systems
@@ -298,14 +288,13 @@ client.activationkey.setDetails(key, '1-mykey', {'contact_method' : 'ssh-push'})
 
 
 It is possible to use Push via SSH to manage systems that are connected to the {productname} server via a proxy.
-To register a system, run [systemitem]``mgr-ssh-push-init``
- on the proxy system for each client you wish to register.
+To register a system, run [systemitem]``mgr-ssh-push-init`` on the proxy system for each client you wish to register.
 Update your proxy with the latest packages to ensure the registration tool is available.
 It is necessary to copy the ssh key to your proxy.
 This can be achieved by executing the following command from the server:
 
 ----
-mgr-ssh-push-init --client`proxy`
+mgr-ssh-push-init --client <proxy>
 ----
 
 [[bp.contact.methods.saltssh.push]]
@@ -328,8 +317,7 @@ For Push via SSH, see <<bp.contact.methods.ssh.push>>.
 image::salt-ssh-contact-taigon.png[scaledwidth=80%]
 
 
-Salt provides "`Salt SSH`"
- ([command]``salt-ssh``), a feature to manage clients from a server.
+Salt provides "`Salt SSH`" ([command]``salt-ssh``), a feature to manage clients from a server.
 It works without installing Salt related software on clients.
 Using Salt SSH there is no need to have minions connected to the Salt master.
 Using this as a {productname} connect method, this feature provides similar functionality for Salt clients as the traditional Push via SSH feature for traditional clients.
@@ -343,14 +331,14 @@ This feature allows:
 === Requirements
 
 * SSH daemon must be running on the remote system and reachable by the [systemitem]``salt-api`` daemon (typically running on the {productname} server).
-* Python must be available on the remote system (Python must be supported by the installed Salt). Currently: python 2.6.
+* Python must be available on the remote system (Python must be supported by the installed Salt).
+Currently: python 2.6.
 
 
 .Unsupported Systems
 [NOTE]
 ====
-{rhel}
-and CentOS versions <= 5 are not supported because they do not have Python 2.6 by default.
+{rhel} and CentOS versions <= 5 are not supported because they do not have Python 2.6 by default.
 ====
 
 === Bootstrapping
@@ -359,7 +347,7 @@ and CentOS versions <= 5 are not supported because they do not have Python 2.6 b
 To bootstrap a Salt SSH system, proceed as follows:
 
 
-. Open the menu:Bootstrap Minions[] dialog in the Web UI (menu:Systems[Bootstrapping] ).
+. Open the menu:Bootstrap Minions[] dialog in the Web UI (menu:Systems[Bootstrapping]).
 . Fill out the required fields. Select an menu:Activation Key[] with the menu:Push via SSH[] contact method configured. For more information about activation keys, see <<ref.webui.systems.activ-keys>>.
 . Check the menu:Manage system completely via SSH[] option.
 . Confirm with clicking the menu:Bootstrap[] button.
@@ -401,7 +389,7 @@ While on traditional clients with SSH push configured only [command]``rhn_check`
 === For More Information
 
 
-For more information, see
+For more information, see:
 
 * https://wiki.microfocus.com/index.php/SUSE_Manager/SaltSSHServerPush
 * https://docs.saltstack.com/en/latest/topics/ssh/


### PR DESCRIPTION
I think we agreed to use \<NAME\> or \<name\> where
```
[replaceable]``name``
```
is not possible.