### PR TITLE
VHM content moved out of Reference, into Admin

### DIFF
--- a/modules/administration/nav-administration-guide.adoc
+++ b/modules/administration/nav-administration-guide.adoc
@@ -19,7 +19,10 @@ ifndef::backend-pdf[]
 // Virtualization
 ** xref:virtualization.adoc[Virtualization]
 ** xref:public-cloud.adoc[Public Cloud]
+// VHMs
 ** xref:virtual-hosts.adoc[Virtual Hosts]
+*** xref:vhm-vmware.adoc[VMWare Virtual Hosts]
+*** xref:vhm-file.adoc[File-based Virtual Hosts]
 // ISS
 ** xref:iss.adoc[Inter-Server Synchronization]
 ** Security
@@ -85,12 +88,16 @@ include::modules/administration/pages/prometheus.adoc[leveloffset=+1]
 include::modules/administration/pages/kubernetes.adoc[leveloffset=+1]
 
 // Virtualization
-// This chapter only applies to traditional clients. Should either be deleted or moved to client cfg. LKB 2019-03-21
 include::modules/administration/pages/virtualization.adoc[leveloffset=+1]
 
 include::modules/administration/pages/public-cloud.adoc[leveloffset=+1]
 
+// VHMs
 include::modules/administration/pages/virtual-hosts.adoc[leveloffset=+1]
+
+include::modules/administration/pages/vhm-vmware.adoc[leveloffset=+2]
+
+include::modules/administration/pages/vhm-file.adoc[leveloffset=+2]
 
 // ISS
 include::modules/administration/pages/iss.adoc[leveloffset=+1]

--- a/modules/administration/pages/vhm-file.adoc
+++ b/modules/administration/pages/vhm-file.adoc
@@ -13,7 +13,7 @@ image::systems_virtual_host_managers_file.png[scaledwidth=80%]
 [NOTE]
 ====
 The file-based option is not meant to be used with manually crafted files.
-It only meant to be used with the output of [command]``virtual-host-gatherer`` against some other module.
+It is only meant to be used with the output of [command]``virtual-host-gatherer`` against some other module.
 File-based is suitable for VMWare vCenter installations for which no direct API access is possible from the {susemgr}.
 
 The solution is to run [command]``virtual-host-gatherer`` from somewhere else in the network and save the produced JSON data for further processing.

--- a/modules/administration/pages/vhm-file.adoc
+++ b/modules/administration/pages/vhm-file.adoc
@@ -1,0 +1,85 @@
+[[vhm-file]]
+= File-based Virtual Hosts
+
+In a VMWare environment where direct connection to the {susemgr} is not possible, a JSON file can be exported from the ESXi or vSphere host and later imported into {productname}.
+
+After selecting menu:Create[File-Based] enter a label and URL leading to the location of this file.
+
+
+image::systems_virtual_host_managers_file.png[scaledwidth=80%]
+
+
+.VMWare vCenter Installations without Direct Access
+[NOTE]
+====
+The file-based is not meant to be used with manually crafted files.
+It only meant to be used with the output of [command]``virtual-host-gatherer`` against some other module.
+File-based is suitable for VMWare vCenter installations for which no direct API access is possible from the {susemgr}.
+
+The solution is to run [command]``virtual-host-gatherer`` from somewhere else in the network and save the produced JSON data for further processing.
+====
+
+
+The following JSON data is an example of the exported information in the file:
+
+----
+{
+    "examplevhost": {
+        "10.11.12.13": {
+            "cpuArch": "x86_64",
+            "cpuDescription": "AMD Opteron(tm) Processor 4386",
+            "cpuMhz": 3092.212727,
+            "cpuVendor": "amd",
+            "hostIdentifier": "'vim.HostSystem:host-182'",
+            "name": "11.11.12.13",
+            "os": "VMware ESXi",
+            "osVersion": "5.5.0",
+            "ramMb": 65512,
+            "totalCpuCores": 16,
+            "totalCpuSockets": 2,
+            "totalCpuThreads": 16,
+            "type": "vmware",
+            "vms": {
+                "vCenter": "564d6d90-459c-2256-8f39-3cb2bd24b7b0"
+            }
+        },
+        "10.11.12.14": {
+            "cpuArch": "x86_64",
+            "cpuDescription": "AMD Opteron(tm) Processor 4386",
+            "cpuMhz": 3092.212639,
+            "cpuVendor": "amd",
+            "hostIdentifier": "'vim.HostSystem:host-183'",
+            "name": "10.11.12.14",
+            "os": "VMware ESXi",
+            "osVersion": "5.5.0",
+            "ramMb": 65512,
+            "totalCpuCores": 16,
+            "totalCpuSockets": 2,
+            "totalCpuThreads": 16,
+            "type": "vmware",
+            "vms": {
+                "49737e0a-c9e6-4ceb-aef8-6a9452f67cb5": "4230c60f-3f98-2a65-f7c3-600b26b79c22",
+                "5a2e4e63-a957-426b-bfa8-4169302e4fdb": "42307b15-1618-0595-01f2-427ffcddd88e",
+                "NSX-gateway": "4230d43e-aafe-38ba-5a9e-3cb67c03a16a",
+                "NSX-l3gateway": "4230b00f-0b21-0e9d-dfde-6c7b06909d5f",
+                "NSX-service": "4230e924-b714-198b-348b-25de01482fd9"
+            }
+        }
+    }
+}
+----
+
+For more information, see the man page on your {productname} server for [command]``virtual-host-gatherer``:
+
+----
+man virtual-host-gatherer
+----
+
+
+The `README` file provided with the package provides background information about the `type` of a hypervisor, etc.:
+
+----
+/usr/share/doc/packages/virtual-host-gatherer/README.md
+----
+
+The man page and the `README` file also contain example configuration files for your reference.

--- a/modules/administration/pages/vhm-file.adoc
+++ b/modules/administration/pages/vhm-file.adoc
@@ -76,7 +76,7 @@ man virtual-host-gatherer
 ----
 
 
-The `README` file provided with the package provides background information about the `type` of a hypervisor, etc.:
+The `README` file of that package provides background information about the `type` of a hypervisor, etc.:
 
 ----
 /usr/share/doc/packages/virtual-host-gatherer/README.md

--- a/modules/administration/pages/vhm-file.adoc
+++ b/modules/administration/pages/vhm-file.adoc
@@ -12,7 +12,7 @@ image::systems_virtual_host_managers_file.png[scaledwidth=80%]
 .VMWare vCenter Installations without Direct Access
 [NOTE]
 ====
-The file-based is not meant to be used with manually crafted files.
+The file-based option is not meant to be used with manually crafted files.
 It only meant to be used with the output of [command]``virtual-host-gatherer`` against some other module.
 File-based is suitable for VMWare vCenter installations for which no direct API access is possible from the {susemgr}.
 

--- a/modules/administration/pages/vhm-file.adoc
+++ b/modules/administration/pages/vhm-file.adoc
@@ -82,4 +82,4 @@ The `README` file of that package provides background information about the `typ
 /usr/share/doc/packages/virtual-host-gatherer/README.md
 ----
 
-The man page and the `README` file also contain example configuration files for your reference.
+The man page and the `README` file also contain example configuration files.

--- a/modules/administration/pages/vhm-vmware.adoc
+++ b/modules/administration/pages/vhm-vmware.adoc
@@ -88,7 +88,7 @@ Assign a username
 
 [IMPORTANT]
 ====
-Remember that only objects and resources which match a user's defined role will be inventoried.
+Only objects and resources that match a user's defined role will be inventoried.
 Set the user's role on objects and resources you want inventoried to _read-only_.
 ====
 +

--- a/modules/administration/pages/vhm-vmware.adoc
+++ b/modules/administration/pages/vhm-vmware.adoc
@@ -1,0 +1,121 @@
+[[vhm-vmware]]
+= VMWare-based Virtual Hosts
+
+
+
+[[advanced.topics.adding.vmware.esxi.host]]
+== Inventorying vCenter/vSphere ESXi Hosts with {productname}
+
+Foreign virtual hosts (such as vCenter and vSphere ESXi) can be inventoried using the [guimenu]``Virtual Host Manager``.
+From the vSphere Client you can define roles and permissions for vCenter and vSphere ESXi users allowing vSphere objects and resources to be imported and inventoried by {productname}.
+Objects and resources are then displayed as foreign hosts on the {productname} menu:System List[Virtual Systems] page.
+
+The following sections will guide you through:
+
+* Requirements
+* Overview of permissions and roles
+* Adding vCenter and vSphere ESXi hosts to {productname}
+
+
+
+
+== Requirements
+
+This table displays the default API communication port and required access rights for inventorying objects and resources:
+
+[cols="1,1", options="header"]
+|===
+| Ports / Permissions | Description
+| 443 | Default port that {productname} uses to access the ESXi API for obtaining infrastructure data
+| read-only | All vCenter/ESXi objects and resources that should be inventoried by the Virtual Host Manager should be at least assigned the _read-only_ role.
+Mark objects and resources with _no-access_ to exclude them from the inventory.
+|===
+
+
+
+== Permissions and Roles Overview
+
+This section will guide you through assigning user permissions and roles in vCenter/ESXi.
+
+A user is someone who has been authorized to access an ESXi host.
+The Virtual Host Manager (located on the SUSE Manager server) will inventory ESXi data defined by assigned roles and permissions on a user account.
+
+For example: The user _John_ has been assigned the _read-only_ access role to all servers and datacenters in his company with one exception.
+John's account has been assigned the _no-access_ role on the company's _Financial Database server_.
+You decide to use John's user account and add the ESXi host to SUSE Manager.
+During the inventory the _Financial Database server_ will be excluded.
+
+Keep user access roles in mind when planning to add ESXi hosts to SUSE manager.
+Note that SUSE Manager will not inventory any objects or resources assigned with the _no-access_ role on any user account.
+
+
+[TIP]
+.User Roles/Permissions
+====
+When planning to add new ESXi hosts to SUSE Manager, consider if the roles and permissions assigned users require need to be inventoried by SUSE Manager.
+====
+
+
+
+== Adding New Users and Assigning Roles
+
+See the official vSphere documentation on adding new users and assigning roles.
+
+* https://pubs.vmware.com/vsphere-50/index.jsp#com.vmware.vsphere.security.doc_50/GUID-D7AEC653-EBC8-4573-B990-D8E58742F8ED.html[Authentication and User Management]
+
+
+
+== Inventorying vCenter/vSphere ESXi Hosts
+
+This procedure guides you through inventorying a VSphere ESXi host with {productname}.
+
+. From the {productname} {webui} select menu:Main Menu[Systems > Virtual Host Managers] from the left navigation bar.
+. From the upper right corner of the _Virtual Host Managers_ page select btn:[Create] VMWare-based.
+. From the _Add a VMware-based Virtual Host Manager_ page complete these fields with your ESXi host data:
+
+Label::
+Custom name for your Virtual Host Manager
+
+Hostname::
+Fully-qualified domain name (FQDN) or host IP address
+
+Port::
+Default ESXi API port
+
+Username::
+Assign a username
++
+
+[IMPORTANT]
+====
+Remember that only objects and resources which match a user's defined role will be inventoried.
+Set the user's role on objects and resources you want inventoried to _read-only_.
+====
++
+
+Password::
+ESXi users password
++
+
+image::systems_virtual_host_managers_vmware.png[scaledwidth=80%]
+
+. Click the btn:[Create] button.
+. From the menu:Systems[Virtual Host Managers] page select the new Virtual Host manager.
+. From the menu:Virtual Host Managers[Properties] page click the btn:[Refresh] button.
++
+
+[IMPORTANT]
+====
+If you do not refresh the data from a new Virtual Host Manager, host data will not be inventoried and therefore will not be displayed under menu:System List[Virtual Systems].
+====
++
+
+. View inventoried ESXi host objects and resources by selecting menu:System List[Virtual Systems].
+
+[NOTE]
+====
+Connecting to the ESXi server from a browser using HTTPS can sometimes log an ``invalid certificate`` error.
+If this occurs, refreshing the data from the virtual hosts server will fail.
+To correct the problem, extract the certificate from the ESXi server, and copy it to [path]``/etc/pki/trust/anchors``.
+Re-trust the certificate by running the [command]``update-ca-certificates`` command on the command line, and restart the spacewalk services.
+====

--- a/modules/administration/pages/virtual-hosts.adoc
+++ b/modules/administration/pages/virtual-hosts.adoc
@@ -1,122 +1,14 @@
 [[virtual-hosts]]
 = Virtual Hosts
 
+Third party hypervisors and hypervisor managers are called Virtual Host Managers (VHMs).
+VHMs can manage one or more virtual hosts, and each virtual host can contain one or more virtual guests.
+VHMs can be based on VMWare, or created from a file.
 
+After your VHM has been created and configured, Taskomatic will run data collection automatically.
+You can also begin data collection manually through the {webui}, by navigating to menu:Systems[Virtual Host Managers], selecting the appropriate VHM, and clicking btn:[Refresh Data].
 
-
-[[advanced.topics.adding.vmware.esxi.host]]
-== Inventorying vCenter/vSphere ESXi Hosts with {productname}
-
-Foreign virtual hosts (such as vCenter and vSphere ESXi) can be inventoried using the [guimenu]``Virtual Host Manager``.
-From the vSphere Client you can define roles and permissions for vCenter and vSphere ESXi users allowing vSphere objects and resources to be imported and inventoried by {productname}.
-Objects and resources are then displayed as foreign hosts on the {productname} menu:System List[Virtual Systems] page.
-
-The following sections will guide you through:
-
-* Requirements
-* Overview of permissions and roles
-* Adding vCenter and vSphere ESXi hosts to {productname}
-
-
-
-
-== Requirements
-
-This table displays the default API communication port and required access rights for inventorying objects and resources:
-
-[cols="1,1", options="header"]
-|===
-| Ports / Permissions | Description
-| 443 | Default port that {productname} uses to access the ESXi API for obtaining infrastructure data
-| read-only | All vCenter/ESXi objects and resources that should be inventoried by the Virtual Host Manager should be at least assigned the _read-only_ role.
-Mark objects and resources with _no-access_ to exclude them from the inventory.
-|===
-
-
-
-== Permissions and Roles Overview
-
-This section will guide you through assigning user permissions and roles in vCenter/ESXi.
-
-A user is someone who has been authorized to access an ESXi host.
-The Virtual Host Manager (located on the SUSE Manager server) will inventory ESXi data defined by assigned roles and permissions on a user account.
-
-For example: The user _John_ has been assigned the _read-only_ access role to all servers and datacenters in his company with one exception.
-John's account has been assigned the _no-access_ role on the company's _Financial Database server_.
-You decide to use John's user account and add the ESXi host to SUSE Manager.
-During the inventory the _Financial Database server_ will be excluded.
-
-Keep user access roles in mind when planning to add ESXi hosts to SUSE manager.
-Note that SUSE Manager will not inventory any objects or resources assigned with the _no-access_ role on any user account.
-
-
-[TIP]
-.User Roles/Permissions
-====
-When planning to add new ESXi hosts to SUSE Manager, consider if the roles and permissions assigned users require need to be inventoried by SUSE Manager.
-====
-
-
-
-== Adding New Users and Assigning Roles
-
-See the official vSphere documentation on adding new users and assigning roles.
-
-* https://pubs.vmware.com/vsphere-50/index.jsp#com.vmware.vsphere.security.doc_50/GUID-D7AEC653-EBC8-4573-B990-D8E58742F8ED.html[Authentication and User Management]
-
-
-
-== Inventorying vCenter/vSphere ESXi Hosts
-
-This procedure guides you through inventorying a VSphere ESXi host with {productname}.
-
-. From the {productname} {webui} select menu:Main Menu[Systems > Virtual Host Managers] from the left navigation bar.
-. From the upper right corner of the _Virtual Host Managers_ page select btn:[Create] VMWare-based.
-. From the _Add a VMware-based Virtual Host Manager_ page complete these fields with your ESXi host data:
-
-Label::
-Custom name for your Virtual Host Manager
-
-Hostname::
-Fully-qualified domain name (FQDN) or host IP address
-
-Port::
-Default ESXi API port
-
-Username::
-Assign a username
-+
-
-[IMPORTANT]
-====
-Remember that only objects and resources which match a user's defined role will be inventoried.
-Set the user's role on objects and resources you want inventoried to _read-only_.
-====
-+
-
-Password::
-ESXi users password
-+
-
-image::systems_virtual_host_managers_vmware.png[scaledwidth=80%]
-
-. Click the btn:[Create] button.
-. From the menu:Systems[Virtual Host Managers] page select the new Virtual Host manager.
-. From the menu:Virtual Host Managers[Properties] page click the btn:[Refresh] button.
-+
-
-[IMPORTANT]
-====
-If you do not refresh the data from a new Virtual Host Manager, host data will not be inventoried and therefore will not be displayed under menu:System List[Virtual Systems].
-====
-+
-
-. View inventoried ESXi host objects and resources by selecting menu:System List[Virtual Systems].
-
-[NOTE]
-====
-Connecting to the ESXi server from a browser using HTTPS can sometimes log an ``invalid certificate`` error.
-If this occurs, refreshing the data from the virtual hosts server will fail.
-To correct the problem, extract the certificate from the ESXi server, and copy it to [path]``/etc/pki/trust/anchors``.
-Re-trust the certificate by running the [command]``update-ca-certificates`` command on the command line, and restart the spacewalk services.
-====
+{productname} ships with a tool called [command]``virtual-host-gatherer`` that can connect to VHMs using their API, and request information about virtual hosts.
+[command]``virtual-host-gatherer`` maintains the concept of optional modules, where each module enables a specific VHM.
+This tool is automatically invoked nightly by Taskomatic.
+Log files for the [command]``virtual-host-gatherer`` tool are located at [path]``/var/log/rhn/gather.log``.

--- a/modules/reference/pages/systems/virtual-host-managers.adoc
+++ b/modules/reference/pages/systems/virtual-host-managers.adoc
@@ -1,174 +1,36 @@
 [[ref.webui.systems.virt-host-managers]]
 = Virtual Host Managers
 
-Third party hypervisors and hypervisor managers such as VMWare vCenter are called "`Virtual Host Managers`" (VHM).
+Third party hypervisors and hypervisor managers are called Virtual Host Managers (VHMs).
 VHMs can manage one or more virtual hosts, and each virtual host can contain one or more virtual guests.
+VHMs can be based on VMWare, or created from a file.
 
-To create a VHM, navigate to menu:Systems[Virtual Host Managers] in the {webui}.
-In the upper right of the page, click btn:[Create] and select either [guimenu]``VMware-based`` or [guimenu]``File-based``.
-Continue according to one of the following procedures.
 
-After it has been created and configured, data collection will be run automatically using Taskomatic.
-You can also begin data collection from your VHMs manually through the {webui}, by navigating to menu:Systems[Virtual Host Managers], selecting the appropriate VHM, and clicking btn:[Refresh Data].
+.Procedure: Creating a VMWare VHM
+
+. In the {productname} {webui}, navigate to menu:Systems[Virtual Host Managers].
+. Click btn:[Create] and select [guimenu]``VMware-based``.
+. Enter the location of your VMware-based virtual host.
+. Enter a [guimenu]``Label``, [guimenu]``Hostname``, [guimenu]``Port``, [guimenu]``Username`` and [guimenu]``Password`` for your VHM.
+. Click the btn:[Add Virtual Host Manager] button.
+
+
+.Procedure: Creating a File-based VHM
+
+. In the {productname} {webui}, navigate to menu:Systems[Virtual Host Managers].
+. Click btn:[Create] and select [guimenu]``File-based``.
+. Enter the location of a JSON file for your VHM.
+This is usually exported directly from the ESXi or vSphere host.
+. Enter a [guimenu]``Label``, [guimenu]``Hostname``, [guimenu]``Port``, [guimenu]``Username`` and [guimenu]``Password`` for your VHM.
+. Click the btn:[Add Virtual Host Manager] button.
+
+
+After your VHM has been created and configured, Taskomatic will run data collection automatically.
+You can also begin data collection manually through the {webui}, by navigating to menu:Systems[Virtual Host Managers], selecting the appropriate VHM, and clicking btn:[Refresh Data].
 
 {productname} ships with a tool called [command]``virtual-host-gatherer`` that can connect to VHMs using their API, and request information about virtual hosts.
-[command]``virtual-host-gatherer`` maintains the concept of optional modules, where each module enables a specific Virtual Host Manager.
+[command]``virtual-host-gatherer`` maintains the concept of optional modules, where each module enables a specific VHM.
 This tool is automatically invoked nightly by Taskomatic.
-Log files for the [command]``virtual-host-gatherer`` tool are located at [path]``/avr/log/rhn/gather.log``.
+Log files for the [command]``virtual-host-gatherer`` tool are located at [path]``/var/log/rhn/gather.log``.
 
-
-
-[[ref.webui.systems.virt-host-managers.vmware]]
-== VMware-Based
-
-
-After selecting menu:Create[VMware-based] enter the location of your VMware-based virtual host.
-Enter a [guimenu]``Label``, [guimenu]``Hostname``, [guimenu]``Port``, [guimenu]``Username`` and [guimenu]``Password``.
-Finally click the btn:[Add Virtual Host Manager] button.
-For detailed information on working with a VMware-based Virtual Host Manager, see xref:administration:virtual-hosts.adoc[].
-
-
-image::systems_virtual_host_managers_vmware.png[scaledwidth=80%]
-
-
-
-[[ref.webui.systems.virt-host-managers.file]]
-== File-Based
-
-In a VMWare environment where direct connection to the {susemgr} is not possible, a JSON file can be exported from the ESXi or vSphere host and later imported into {productname}.
-
-After selecting menu:Create[File-Based] enter a label and URL leading to the location of this file.
-
-
-image::systems_virtual_host_managers_file.png[scaledwidth=80%]
-
-
-.VMWare vCenter Installations without Direct Access
-[NOTE]
-====
-The file-based is not meant to be used with manually crafted files.
-It only meant to be used with the output of [command]``virtual-host-gatherer`` against some other module.
-File-based is suitable for VMWare vCenter installations for which no direct API access is possible from the {susemgr}.
-
-The solution is to run [command]``virtual-host-gatherer`` from somewhere else in the network and save the produced JSON data for further processing.
-====
-
-
-The following JSON data is an example of the exported information in the file:
-
-----
-{
-    "examplevhost": {
-        "10.11.12.13": {
-            "cpuArch": "x86_64",
-            "cpuDescription": "AMD Opteron(tm) Processor 4386",
-            "cpuMhz": 3092.212727,
-            "cpuVendor": "amd",
-            "hostIdentifier": "'vim.HostSystem:host-182'",
-            "name": "11.11.12.13",
-            "os": "VMware ESXi",
-            "osVersion": "5.5.0",
-            "ramMb": 65512,
-            "totalCpuCores": 16,
-            "totalCpuSockets": 2,
-            "totalCpuThreads": 16,
-            "type": "vmware",
-            "vms": {
-                "vCenter": "564d6d90-459c-2256-8f39-3cb2bd24b7b0"
-            }
-        },
-        "10.11.12.14": {
-            "cpuArch": "x86_64",
-            "cpuDescription": "AMD Opteron(tm) Processor 4386",
-            "cpuMhz": 3092.212639,
-            "cpuVendor": "amd",
-            "hostIdentifier": "'vim.HostSystem:host-183'",
-            "name": "10.11.12.14",
-            "os": "VMware ESXi",
-            "osVersion": "5.5.0",
-            "ramMb": 65512,
-            "totalCpuCores": 16,
-            "totalCpuSockets": 2,
-            "totalCpuThreads": 16,
-            "type": "vmware",
-            "vms": {
-                "49737e0a-c9e6-4ceb-aef8-6a9452f67cb5": "4230c60f-3f98-2a65-f7c3-600b26b79c22",
-                "5a2e4e63-a957-426b-bfa8-4169302e4fdb": "42307b15-1618-0595-01f2-427ffcddd88e",
-                "NSX-gateway": "4230d43e-aafe-38ba-5a9e-3cb67c03a16a",
-                "NSX-l3gateway": "4230b00f-0b21-0e9d-dfde-6c7b06909d5f",
-                "NSX-service": "4230e924-b714-198b-348b-25de01482fd9"
-            }
-        }
-    }
-}
-----
-
-For more information, see the man page on your {productname} server for [command]``virtual-host-gatherer``:
-
-----
-man virtual-host-gatherer
-----
-
-
-The `README` file provided with the package provides background information about the `type` of a hypervisor, etc.:
-
-----
-/usr/share/doc/packages/virtual-host-gatherer/README.md
-----
-
-The man page and the `README` file also contain example configuration files for your reference.
-
-
-
-== Configuring Virtual Host Managers using the XMLRPC API
-
-VHMs can be managed manually using the {webui}, or programtically using XMLRPC.
-If you want to to manage your VHMs with XMLRPC, you will need to configure them to use the XMLRPC APIs.
-
-The following APIs allow you to get a list of available [command]``virtual-host-manager`` modules and the parameters they require:
-
-* {empty}
-+
-
-----
-virtualhostmanager.listAvailableVirtualHostGathererModules(session)
-----
-* {empty}
-+
-
-----
-virtualhostmanager.getModuleParameters(session, moduleName)
-----
-
-
-The following APIs allow you to create and delete VHMs.
-The module parameter map must match the map returned by `virtualhostmanager.getModuleParameters` to work correctly:
-
-* {empty}
-+
-
-----
-virtualhostmanager.create(session, label, moduleName, parameters)
-----
-* {empty}
-+
-
-----
-virtualhostmanager.delete(session, label)
-----
-
-
-The following APIs return information about configured VHMs:
-
-* {empty}
-+
-
-----
-virtualhostmanager.listVirtualHostManagers(session)
-----
-* {empty}
-+
-
-----
-virtualhostmanager.getDetail(session, label)
-----
+For more information on VHMs, see xref:administration:virtual-hosts.adoc[].


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1139931
https://github.com/SUSE/spacewalk/issues/8239

This resolves the bug, but there's some follow up work to be done:

- [ ] Edit both modules/administration/pages/vhm-vmware.adoc and modules/administration/pages/vhm-file.adoc: https://github.com/SUSE/spacewalk/issues/8255
- [ ] Move other Concept/Task information out of the Reference Guide: https://github.com/SUSE/spacewalk/issues/8256