### PR TITLE
Please remove warning notes for prerelease versions

### DIFF
--- a/modules/ROOT/pages/release-notes-version-4.0.adoc
+++ b/modules/ROOT/pages/release-notes-version-4.0.adoc
@@ -209,6 +209,7 @@ We have added a prototype of real time search using Algolia.
 We are still developing an alternative for offline reading.
 
 
+The search feature of this beta release is a prototype and points to development and testing sources.
 [[new-ui]]
 === Antora Static Site
 

--- a/modules/ROOT/pages/release-notes-version-4.0.adoc
+++ b/modules/ROOT/pages/release-notes-version-4.0.adoc
@@ -161,15 +161,6 @@ In this new layout, you can propose changes directly by clicking the btn:[Edit t
 You can also report an issue by clicking [guimenu]``Report Issue`` in the [guimenu]``Resources`` menu.
 
 
-[WARNING]
-====
-Do not use this documentation for production!
-The documentation on this site is being offered as a preview of changes to come.
-They are for testing purposes only.
-====
-
-
-
 === Goals for this Release
 
 * <<cleanup-ia>>
@@ -216,14 +207,6 @@ All {productname} books have been reworked into a new structure.
 
 We have added a prototype of real time search using Algolia.
 We are still developing an alternative for offline reading.
-
-
-[IMPORTANT]
-====
-Do not use this feature for production!
-The search feature is currently a prototype and points to development and testing sources.
-====
-
 
 
 [[new-ui]]


### PR DESCRIPTION
They do not add anything useful anymore and can only mislead the reader into thinking the current version of SUSE Manager / Uyuni is not ready for production.

This kind of warnings should only be in the very version where they are relevant, and be removed in the next version.