### PR TITLE
Fix issue on ISS doc: "mgr-inter-sync" needs to run on the slave

### DIFF
--- a/modules/administration/pages/iss.adoc
+++ b/modules/administration/pages/iss.adoc
@@ -27,7 +27,7 @@ Click btn:[Add new master] to add the ISS master.
 . Click btn:[Create] to add the ISS slave.
 . In the [guimenu]``Allow Export of the Selected Organizations`` section, check the organizations you want to allow this slave to export to the master, and click btn:[Allow Orgs].
 
-When you have the master and slaves set up, you can perform a synchronization from the command line on the master, with this command:
+When you have the master and slaves set up, you can perform a synchronization from the command line on the slave, with this command:
 
 ----
 mgr-inter-sync


### PR DESCRIPTION
This PR fixes an issue on the "Inter Server Sync (ISS)" documentation.

After setting the Master and Slave servers properly, the `mgr-inter-sync` command needs to be executed on the **slave** server and not in the **master** as documentation says.

This is a port of https://github.com/uyuni-project/uyuni-docs/pull/3