### PR TITLE
Remove internal notes

### DIFF
--- a/modules/administration/pages/tshoot-osadjabberd.adoc
+++ b/modules/administration/pages/tshoot-osadjabberd.adoc
@@ -97,27 +97,3 @@ The following procedures provide information on capturing data from both the cli
 . Open a second terminal and start the OSA process: [command]``rcosad start``
 . Operate the SUSE Manager server and clients so the bug you formerly experienced is reproduced.
 . Once you have finished your capture re-open terminal 1 and stop the capture of data with: kbd:[CTRL+c]
-
-
-== Engineering Notes: Analyzing Captured Data
-
-
-This section provides information on analyzing the previously captured data from client and server.
-
-
-. Obtain the certificate file from your SUSE Manager server: /etc/pki/spacewalk/jabberd/server.pem
-. Edit the certificate file removing all lines before ``----BEGIN RSA PRIVATE KEY-----``, save it as key.pem
-. Install Wireshark as root with: [command]``zypper in wireshark``
-. Open the captured file in wireshark.
-. From menu:Eidt[]menu:Preferences[] select SSL from the left pane.
-. Select RSA keys list: menu:Edit[]menu:New[]
-** IP Address any
-** Port: 5222
-** Protocol: xmpp
-** Key File: open the key.pem file previously edited.
-** Password: leave blank
-
-+
-For more information see also:
-** https://wiki.wireshark.org/SSL
-** https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=3444


### PR DESCRIPTION
Engineering notes were copied from the Wiki but are meant to be internal for our engineers, should not really be relevant for users.

Part of https://github.com/SUSE/spacewalk/issues/5217