### PR TITLE
Ref guide: Remove wrong image

### DIFF
--- a/modules/reference/pages/systems/system-details/sd-remote-command.adoc
+++ b/modules/reference/pages/systems/system-details/sd-remote-command.adoc
@@ -3,8 +3,6 @@
 
 This subtab allows you to run remote commands on the selected system. Before doing so, you must first configure the system to accept such commands.
 
-image::system_details_traditional_edit.png[scaledwidth=80%]
-
 . On {slea} clients, subscribe the system to the {productname} Tools child channel.
 Then use Zypper to install the [systemitem]``rhncfg``, [systemitem]``rhncfg-client``, and [systemitem]``rhncfg-actions`` packages, if not already installed:
 +


### PR DESCRIPTION
https://github.com/SUSE/spacewalk/issues/5554

Removed the incorrect image in latest. I don't think it's worth backporting this.