### PR TITLE
Add Canonical IP safeguard

### DIFF
--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -4,19 +4,11 @@
 
 This section contains information about registering Salt clients running {ubuntu} operating systems.
 
-Support for {ubuntu} Clients was added in {susemgr} 3.2.
+{susemgr} supports {ubuntu} 16.04 LTS and 18.04 LTS Clients using Salt. Traditional clients are not supported.
 
-[NOTE]
-====
-Salt clients running {ubuntu} 16.04 LTS and 18.04 LTS are supported.
-Traditional clients are not supported.
-====
+Supported features:
 
-Bootstrapping is supported for starting {ubuntu} clients and performing initial state runs such as setting repositories and performing profile updates.
-However, the root user on {ubuntu} is disabled by default, so in order to use bootstrapping, you will require an existing user with [command]``sudo`` privileges for Python.
-
-Other supported features:
-
+* Bootstrapping
 * Synchronizing [systemitem]``.deb`` channels
 * Assigning [systemitem]``.deb`` channels to clients
 * GPG signing [systemitem]``.deb`` repositories
@@ -24,6 +16,10 @@ Other supported features:
 * Package install, update, and remove
 * Package install using [systemitem]``Package States``
 * Configuration and state channels
+
+Bootstrapping is supported for starting {ubuntu} clients and performing initial state runs such as setting repositories and performing profile updates.
+However, the root user on {ubuntu} is disabled by default, so in order to use bootstrapping, you will require an existing user with [command]``sudo`` privileges for Python.
+
 
 Some actions are not yet supported:
 
@@ -36,6 +32,10 @@ Some actions are not yet supported:
 // We are waiting for SMT to release the feature/fix to mirror Debian repositories. When this has been done, this comment and the limitation above can be removed.
 
 
+[NOTE]
+====
+Canonical does not endorse or support {susemgr}.
+====
 
 == Prepare to Register {ubuntu} Clients
 

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -4,7 +4,8 @@
 
 This section contains information about registering Salt clients running {ubuntu} operating systems.
 
-{susemgr} supports {ubuntu} 16.04 LTS and 18.04 LTS Clients using Salt. Traditional clients are not supported.
+{susemgr} supports {ubuntu} 16.04 LTS and 18.04 LTS Clients using Salt. 
+Traditional clients are not supported.
 
 Supported features:
 


### PR DESCRIPTION
For IP reasons, add note about Canonical not supporting or endorsing SUSE Manager. We should have had that since the very beginning:
https://ubuntu.com/legal/intellectual-property-policy

Also, make a bit more straightforward the first part of the page.
