### PR TITLE
mgr-sync logging

### DIFF
--- a/modules/reference/pages/command-line-tools.adoc
+++ b/modules/reference/pages/command-line-tools.adoc
@@ -702,8 +702,7 @@ Show help message and exit.
 With [command]``mgr-sync`` you may add or synchronize products and channels.
 The [command]``mgr-sync`` command also enables and refreshes SCC data.
 
-By default [command]``mgr-sync`` writes basic debug information to
-[path]``/var/log/rhn/mgr-sync.log``.
+By default, [command]``mgr-sync`` writes basic debug information to [path]``/var/log/rhn/mgr-sync.log``.
 Further debugging information can be obtained by either with [option]``--debug`` or adding [literal]``mgrsync.debug = <DEBUGLEVEL>`` to [path]``/etc/rhn/rhn.conf``.
 
 [IMPORTANT]

--- a/modules/reference/pages/command-line-tools.adoc
+++ b/modules/reference/pages/command-line-tools.adoc
@@ -703,7 +703,7 @@ With [command]``mgr-sync`` you may add or synchronize products and channels.
 The [command]``mgr-sync`` command also enables and refreshes SCC data.
 
 By default, [command]``mgr-sync`` writes basic debug information to [path]``/var/log/rhn/mgr-sync.log``.
-Further debugging information can be obtained by either with [option]``--debug`` or adding [literal]``mgrsync.debug = <DEBUGLEVEL>`` to [path]``/etc/rhn/rhn.conf``.
+Get more debugging information with [option]``--debug`` or by adding [literal]``mgrsync.debug = <DEBUGLEVEL>`` to [path]``/etc/rhn/rhn.conf``.
 
 [IMPORTANT]
 .Admin credentials

--- a/modules/reference/pages/command-line-tools.adoc
+++ b/modules/reference/pages/command-line-tools.adoc
@@ -702,12 +702,9 @@ Show help message and exit.
 With [command]``mgr-sync`` you may add or synchronize products and channels.
 The [command]``mgr-sync`` command also enables and refreshes SCC data.
 
-
-By default, log rotation of [path]``spacewalk-repo-sync`` is disabled.
-This logfile is run by a cron job, and managed by a configuration file.
-You can enable log rotation by editing the configuration file at [path]``etc/sysconfig/rhn/reposync`` and setting the [command]``MAX_DAYS`` parameter.
-This will permit the deletion of files that are older than the specified period of time.
-
+By default [command]``mgr-sync`` writes basic debug information to
+[path]``/var/log/rhn/mgr-sync.log``.
+Further debugging information can be obtained by either with [option]``--debug`` or adding [literal]``mgrsync.debug = <DEBUGLEVEL>`` to [path]``/etc/rhn/rhn.conf``.
 
 [IMPORTANT]
 .Admin credentials

--- a/modules/reference/pages/command-line-tools.adoc
+++ b/modules/reference/pages/command-line-tools.adoc
@@ -696,7 +696,7 @@ Show help message and exit.
 
 
 [[syncing.suse.mgr.repositories.scc]]
-== Syncing SUSE Manager Repositories from SCC (mgr-sync)
+== Synchronize SUSE Manager Repositories from SCC (mgr-sync)
 
 [command]``mgr-sync`` should be used if SUSE Manager is connected to SUSE Customer Center (SCC).
 With [command]``mgr-sync`` you may add or synchronize products and channels.
@@ -704,11 +704,16 @@ The [command]``mgr-sync`` command also enables and refreshes SCC data.
 
 By default, [command]``mgr-sync`` writes basic debug information to [path]``/var/log/rhn/mgr-sync.log``.
 Get more debugging information with [option]``--debug`` or by adding [literal]``mgrsync.debug = <DEBUGLEVEL>`` to [path]``/etc/rhn/rhn.conf``.
+Settings in [path]``~/.mgr-sync`` will supersede values from [path]``rhn.conf``. For example, if you set
+----
+mgrsync.debug = ""
+----
+in [path]``~/.mgr-sync``, the value in [path]``rhn.conf`` will have no effect. 
 
 [IMPORTANT]
 .Admin credentials
 ====
-[command]``mgr-sync`` now requires the username/password of a *SUSE Manager administrator*.
+[command]``mgr-sync`` requires username and password of a *SUSE Manager administrator*.
 Most functions are available as part of the public API.
 ====
 


### PR DESCRIPTION
Info about logging taken from the manpage.
@mcalmer does it make sense this way?  The previous version looked like a cut-and-paste error to me.