### PR TITLE
add migrate-3x-4x.adoc to the nav (2 times)

### DIFF
--- a/modules/upgrade/nav-upgrade-guide.adoc
+++ b/modules/upgrade/nav-upgrade-guide.adoc
@@ -3,8 +3,9 @@ ifndef::backend-pdf[]
 
 * xref:upgrade-overview.adoc[Upgrade Guide]
 ** xref:server-upgrade.adoc[Server Update]
+** xref:migrate-3x-4x.adoc[Migrating from Version 3.2 to 4.x]
 ** xref:migrate-4x-4x.adoc[Migrating from Version 4 to 4.x]
-** xref:proxy-migration.adoc[Proxy Upgrade 3.x -> 4.x]
+** xref:proxy-migration.adoc[Proxy Upgrade 3.x to 4.x]
 ** xref:client-migration.adoc[Client Migration]
 ** xref:db-migration.adoc[Database Migration]
 ** xref:troubleshooting.adoc[Troubleshooting]
@@ -29,6 +30,9 @@ include::modules/upgrade/pages/upgrade-overview.adoc[leveloffset=+1]
 
 // Server upgrade
 include::modules/upgrade/pages/server-upgrade.adoc[leveloffset=+1]
+
+// Migration from Version 3x to 4x
+include::modules/upgrade/pages/migrate-3x-4x.adoc[leveloffset=+1]
 
 // Migration from Version 4x to 4x
 include::modules/upgrade/pages/migrate-4x-4x.adoc[leveloffset=+1]


### PR DESCRIPTION
somehow forgotten or lost since earlier this year.

Here is an old changelog entry:

commit cb32b96147d28db5a0d7b0913c82ded1c2185ef1
Author: Karl Eichwalder <ke@suse.de>
Date:   Thu May 23 12:49:52 2019 +0200

    new section about migrating 3.2 servers to 4 (#467)
