### PR TITLE
Update clients-rh.adoc

### DIFF
--- a/modules/client-configuration/nav-client-config-guide.adoc
+++ b/modules/client-configuration/nav-client-config-guide.adoc
@@ -19,6 +19,7 @@ ifndef::backend-pdf[]
 *** xref:disconnected-setup.adoc[Disconnected Setup]
 // Non-SUSE Clients
 ** xref:non-suse-clients.adoc[Other Clients]
+*** xref:clients-sleses.adoc[Expanded Support Clients]
 *** xref:clients-rh.adoc[Red Hat Clients]
 *** xref:clients-centos.adoc[CentOS Clients]
 *** xref:clients-ubuntu.adoc[Ubuntu Clients]
@@ -83,6 +84,8 @@ include::modules/client-configuration/pages/disconnected-setup.adoc[leveloffset=
 // Non-SUSE Clients
 
 include::modules/client-configuration/pages/non-suse-clients.adoc[leveloffset=+1]
+
+include::modules/client-configuration/pages/clients-sleses.adoc[leveloffset=+2]
 
 include::modules/client-configuration/pages/clients-rh.adoc[leveloffset=+2]
 

--- a/modules/client-configuration/pages/clients-centos.adoc
+++ b/modules/client-configuration/pages/clients-centos.adoc
@@ -1,158 +1,84 @@
 [[clients-centos]]
 = Registering {centos} Clients
 
-
 This section contains information about registering traditional and Salt clients running {centos} operating systems.
 
+[WARNING]
+====
+{centos} Clients are completely based on {centos} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesa})
+You are responsible for arranging access to {centos} base media repositories and {centos} installation media, as well as connecting {productname} Server to {centos} Content Delivery Network
+ifeval::[{suma-content} == true]
+{suse} does not provide support for {centos} operating system.
+Currently {centos} works with {productname} but support is not provided
+endif::[]
+====
 
+== Server requirements
 
-== Set up a {centos} Client
+Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
-The [package]``spacewalk-utils`` package contains a number of upstream command line tools required for client administration.
-You will also require the [command]``spacewalk-common-channels`` tool.
+Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
+
+To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+
+----
+taskomatic.java.maxmemory=3072
+----
+
+Restart Taskomatic:
+----
+systemctl restart taskomatic
+----
+
+== {centos} Channel and Repository Management
+
+.Procedure: Add the Channels and Repositories
+
+The [package]``spacewalk-utils`` package contains a number of command line tools required for client administration, including [command]``spacewalk-common-channels`` tool.
+
+ifeval::[{suma-content} == true]
+[WARNING]
+====
 Keep in mind {suse} only provides support for [command]``spacewalk-clone-by-date`` and [command]``spacewalk-manage-channel-lifecycle`` tools.
+====
+endif::[]
 
-The [path]``/etc/rhn/spacewalk-common-channels.ini`` configuration file must contain the channel references you want to add.
-If a channel is not listed, check the latest version for updates: https://github.com/spacewalkproject/spacewalk/tree/master/utils
+At the command prompt on the {productname} Server, as root, install the [package]``spacewalk-utils`` package:
 
-You will also need an activation key associated with the {centos} channel.
-For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
-
-
-.Procedure: Adding Channels and Repositories
-
-. At the command prompt on the {productname} Server, as root, install the [package]``spacewalk-utils`` package:
-+
 ----
 zypper in spacewalk-utils
 ----
-. Add the {centos} base, updates, and client channels using the [command]``spacewalk-common-channels`` script:
-+
+
+Add the {centos} base, updates, and client channels using the [command]``spacewalk-common-channels`` script (adapt to your CentOS version and architecture):
 ----
-spacewalk-common-channels -u admin -p`secret`-a x86_64 'centos7'
-spacewalk-common-channels -u admin -p`secret`-a x86_64 'centos7-updates'
-spacewalk-common-channels -u admin -p`secret`-a x86_64 'centos7-uyuni-client-x86_64'
+spacewalk-common-channels -a x86_64 centos7 centos7-uyuni-client centos7-uyuni-client
 ----
 
-.Procedure: Synchronizing {centos} Clients
+.Procedure: Syncronize {centos} repositories
 
-. In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and select the base channel you want to synchronize.
+In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and select the base channel you want to synchronize.
+
 . In the [guimenu]``Repositories`` tab, navigate to the [guimenu]``Sync`` subtab, and click btn:[Sync Now].
 You can also create a regular synchronization schedule on this page.
 
 When you have prepared you {productname} Server, you can install your {centos} client using your preferred installation media and method.
 
-.Procedure: Setting up a {centos} Client
+== Create an activation key
 
-. At the command prompt, copy all relevant GPG keys to [path]``/srv/www/htdocs/pub``.
-If you intend to use a bootstrap script to register your client, you can add the GPG keys to your bootstrap script.
-. Check that the client machine can resolve itself and your {productname} Server using DNS.
-. Check that there is an entry in [path]``/etc/hosts`` for the real IP address of the client.
-. Create an activation key called `centos7` on the {productname} Server that points to the correct parent and child channels, including the {centos} base repository, updates, and client channels.
+You will also need an activation key associated with the {centos} channels (6 or 7) created on the previous setp
+
+For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+
+== Trust GPG keys at the clients
+
+The GPG key for Uyuni CentOS Client Tools is not trusted by default by CentOS.
+
+The systems will bootstrap without the GPG key being trusted, but will not be able to install new client tool packages or updated them.
+
+This can be fixed by adding the key ``uyuni-gpg-pubkey-0d20833e.key`` to all the CentOS bootscrap scripts at variable ``ORG_GPG_KEY=``. If you already have other keys there, you can keep them.
+
+For systems bootstrapped from WebUI, a salt state should be created to trust the key, then the state can be assigned to the organization, and finally it can be used using an Activation Key and the Configuration Channels to deploy the change to the clients.
+
+== Register {centos} Clients
 
 When you are ready to register your {centos} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
-
-
-////
-This is all duplicated content. LKB 2018-08-31
-
-Now prepare the bootstrap script.
-
-[[proc.bp.expanded-support.centos-repos.trad.bsscript]]
-.Procedure: Preparing the Bootstrap Script
-. Create/edit your bootstrap script to correctly reflect the following:
-+
-
-----
-# can be edited, but probably correct (unless created during initial install):
-
-# NOTE: ACTIVATION_KEYS *must* be used to bootstrap a client machine.
-
-ACTIVATION_KEYS=1-centos7
-
-ORG_GPG_KEY=res.key,RPM-GPG-KEY-CentOS-7,suse-307E3D54.key,suse-9C800ACA.key,RPM-GPG-KEY-spacewalk-2015
-
-FULLY_UPDATE_THIS_BOX=0
-
-yum clean all
-# Install the prerequisites
-yum -y install yum-rhn-plugin rhn-setup
-----
-. Add the following lines to the bottom of your script, (just before `echo "`-bootstrap complete -`"`):
-+
-
-----
-# This section is for commands to be executed after registration
-mv /etc/yum.repos.d/Cent* /root/
-yum clean all
-chkconfig rhnsd on
-chkconfig osad on
-service rhnsd restart
-service osad restart
-----
-. Continue by following normal bootstrap procedures to bootstrap the new client.
-
-
-[[bp.expanded-support.centos_salt]]
-== Registering CentOS Salt Clients with {productname}
-
-
-The following procedure will guide you through registering a CentOS client.
-
-.Support for CentOS Patches
-[WARNING]
-====
-
-CentOS uses patches originating from CentOS is not officially supported by {suse}
-.
-See the matrix of {productname} clients on the main page of the {productname} wiki, linked from the [ref]_Quick Links_ section: https://wiki.microfocus.com/index.php?title=SUSE_Manager
-
-====
-
-////
-
-
-////
-I'm fairly certain this isn't supported, which is why we took it out of the SLE instructions. LKB 2018-08-12
-
-
-.Procedure: Register a CentOS 7 Client
-. Add the Open Build Service repo for Salt:
-+
-
-----
-yum-config-manager --add-repo http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/RHEL_7/
-----
-. Import the repo key:
-+
-
-----
-rpm --import http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/RHEL_7/repodata/repomd.xml.key
-----
-. Check if there is a different repository that contains Salt. If there is more than one repository listed disable the repository that contains Salt apart from the OBS one.
-+
-
-----
-yum list --showduplicates salt
-----
-. Install the Salt client:
-+
-
-----
-yum install salt salt-minion
-----
-. Change the Salt configuration to point to the {productname} server:
-+
-
-----
-mkdir -p /etc/salt/minion.d
-echo "master:`server_fqdn`" > /etc/salt/minion.d/susemanager.conf
-----
-. Restart the client
-+
-
-----
-systemctl restart salt-minion
-----
-. Proceed to menu:Main Menu[Salt > Keys] from the {webui} and accept the client's key.
-////

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -6,25 +6,7 @@ This section contains information about registering traditional and Salt clients
 
 
 
-== Set up a {rhel} Client
-
-Ensure that your client meets these requirements before you start:
-
-* 8{nbsp}GB RAM or more
-* Two or more physical or virtual CPU cores
-* Access to {rhel} installation and subscription media
-* An LVM or an NFS mount is recommended
-
-You will need to ensure you provision enough disk space.
-The [path]``/var/spacewalk`` directory contains all mirrored RPMs,  and can take a significant amount of disk space.
-For example, the {rhel}{nbsp}6 x86_64 channels require over 90{nbsp}GB.
-
-Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
-To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, and add this line:
-
-----
-taskomatic.java.maxmemory=3072
-----
+== Server requirements
 
 [WARNING]
 ====
@@ -33,7 +15,20 @@ You must obtain support from either Red Hat or {suse} for all your RHEL systems.
 If you do not do this, you might be violating your terms with Red Hat.
 ====
 
+Ensure that your server meets the requirements outlined at installation:hardware-requirements.adoc
 
+Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
+
+To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+
+----
+taskomatic.java.maxmemory=3072
+----
+
+And restart Taskomatic:
+----
+systemctl restart taskomatic
+----
 
 == {rhel} Channel Management
 

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -1,19 +1,17 @@
 [[clients-rh]]
 = Registering {rhel} Clients
 
-
 This section contains information about registering traditional and Salt clients running {rhel} operating systems.
-
-
-
-== Server requirements
 
 [WARNING]
 ====
-You are responsible for arranging access to Red Hat base media repositories and RHEL installation media.
-You must obtain support from either Red Hat or {suse} for all your RHEL systems.
-If you do not do this, you might be violating your terms with Red Hat.
+{rhel} Clients are completely based on {redhat} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesa})
+You are responsible for arranging access to {redhat} base media repositories and {rhela} installation media, as well as connecting {productname} Server to {redhat} Content Delivery Network
+You must obtain support from either {redhat} all your {rhela} systems.
+If you do not do this, you might be violating your terms with {redhat}.
 ====
+
+== Server requirements
 
 Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
@@ -30,120 +28,245 @@ Restart Taskomatic:
 systemctl restart taskomatic
 ----
 
-== {rhel} Channel Management
+== Import {redhat} Entitlement and CA Certificate
 
-=== Add {rhel} product from SCC
+During the next few paragraphs, you will learn how to import the {redhat} CA and entitlement certificate.
 
-Before you register {rhel} clients to your {productname} Server, check that you have the corresponding {rhel} product enabled, and the required channels are fully synchronized.
-
-You will also need an activation key associated with the {rhel} channel.
-For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
-
-{rhel} 7::
-* Product: {rhel} 7
-* Mandatory channels: [systemitem]``rhel-x86_64-server-7`` , [systemitem]``res7-suse-manager-tools-x86_64`` , [systemitem]``res7-x86_64``
-
-
-{rhel} 6::
-* Product: {rhel} 6
-* Mandatory channels: [systemitem]``rhel-x86_64-server-6`` , [systemitem]``res6-suse-manager-tools-x86_64`` , [systemitem]``res6-x86_64``
-
-
-There are two ways to check if a channel has finished synchronizing:
-
-* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
-This dialog displays a completion bar for each product when they are being synchronized.
-* You can also check the synchronization log file at the command prompt.
-Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
-If you use this method, remember that base channels can contain multiple child channels.
-Each of the child channels will generate its own log during the synchronization progress.
-You will need to check all the base and child channel log files to be sure that the synchronization is complete.
-
-[IMPORTANT]
+[WARNING]
 ====
-Missing packages will cause your registration to fail.
-For {rhel} clients, packages are contained on the {rhel} installation media.
-Ensure you have loop-mounted the installation media, and added it as a child channel to the base {rhel} channel.
+Entitlement certificates have embedded expiration dates tied to the length of the support subscription. You must repeat this process with updated entitlement certificates as needed to avoid disruption in channel mirroring.
 ====
 
-=== Add {rhel} media
+==== Entitlement Certificate
 
-The base {rhel} software channel does not contain any packages.
-This is because {suse} does not provide {rhel} base media.
-You will need to obtain base media from Red Hat, which you can then add as a child channel to the {rhel} parent channel.
+{redhat} Subscription Manager is a local service which tracks installed products and subscriptions on a local system to help manage subscription assignments. To obtain your certificates, you must register your system using this subscription manager tool supplied by {redhat}.
 
-The {rhel} and tools channels are provided by {scc}.
-You can synchronize your client with the [command]``mgr-sync`` command to get them.
+1. Register with the subscription manager tool from your {redhat} client. It will prompt you for your user name and password for authentication on the {redhat} Portal:
 
-Because the {rhel} channels are particularly large, it can take up to 24 hours for an initial channel synchronization to complete.
-When you have completed the initial synchronization, we recommended you clone the channel before working with it.
-This provides you with a backup of the original synchronization data.
-
-The following procedure guides you through setup of the {rhel} media as a {productname} channel.
-All packages on the media will be mirrored into a child channel located under the distribution name and architecture.
-
-.Procedure: Setting up a {rhel} Channel
-. In the {productname} {webui}, navigate to menu:Channels[Manage Software Channels], and click btn:[Create Channel].
-. Fill in the channel details, and add the channel as a child to the corresponding {rhel} distribution channel for your architecture.
-The base parent channel will not contain any packages.
-. Modify the associated activation key to include your new child channel.
-. At the command prompt, as root, copy your installation disk image to the [path]``/tmp`` directory.
-. Create a directory to contain the media content:
-+
 ----
-mkdir -p /srv/www/htdocs/pub/rhel
-----
-. Mount the ISO:
-+
-----
-mount -o loop /tmp/name_of_iso /srv/www/htdocs/pub/rhel
-----
-. Synchronize the packages with [command]``spacewalk-repo-sync``:
-+
-For {rhel} 7:
-+
-----
-spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/
-Repo URL: https://127.0.0.1/pub/rhel/
-Packages in repo:              [...]
-Packages already synced:       [...]
-Packages to sync:              [...]
-[...]
-----
-+
-For {rhel} 6:
-+
-----
-spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/Server/
-Repo URL: https://127.0.0.1/pub/rhel/Server/
-Packages in repo:              [...]
-Packages already synced:       [...]
-Packages to sync:              [...]
-[...]
+subscription-manager register
 ----
 
-Sometimes, the [command]``spacewalk-repo-sync`` will stop running during a synchronization, which will give this error:
+2. Navigate to the location of your entitlement certificate and key, and copy these files to where your Web browser connected to {productname} Server can open them:
+
 ----
-[Errno 256] No more mirrors to try.
+cd /etc/pki/entitlement/
 ----
 
-If this occurs, you can run [command]``spacewalk-repo-sync`` in debugging mode to determine the error.
+You will see two files with the data file format extension .pem (Program Editor macro). One is the certificate, and the other is the key and it has the word “key” in the file name.
 
-Start debugging mode:
-----
-export URLGRABBER_DEBUG=DEBUG
-----
+==== {redhat} CA Certificate
 
-Check the output:
-----
-/usr/bin/spacewalk-repo-sync --channel <channel-label> --type yum
-----
+The next step is to get the {redhat} CA Certificate file. It is located on this same {redhat} system in the file [path]``/etc/rhsm/ca/redhat-uep.pem``. Place this file in the same location where, in the previous section, you put the entitlement certificate.
 
-Disable debug mode:
+==== Obtain Repository URL list
+
+Use the subscription manager tool to obtain the URL’s of the repositories you want to mirror:
+
 ----
-unset URLGRABBER_DEBUG
+subscription-manager repos
 ----
 
-== Register {rhel} Clients
+==== Import
+
+Now you are ready to import the {redhat} CA Certificate and Entitlement Certificate into {productname} Server for software repository mirroring. You must create three entries here: one each for the entitlement certificate, the entitlement key, and the {redhat} certificate.
+
+* In the {productname} {webui}, navigate to menu:Systems[Autoinstallation > GPG and SSL Keys].
+
+// Maybe we  should add a screenshot, as we have at the current guide: https://documentation.suse.com/sbp/all/html/SBP-sumaforrhel/index.html#sec-import
+
+* Click **Create Stored Key/Cert** on the right. Another screen opens where you can fill in the required information.
+
+// Another screenshot.
+
+Enter the following values, and ensure you enter the date:
+
+**Description:** Entitlement-Cert-date
+**Type:** Ensure you select SSL
+**Select file to upload:** Browse to where you saved the Entitlement Certificate .pem file and select it.
+
+Click the btn:[Create Key] at the bottom.
+
+Repeat the above steps for the Entitlement Key and change the values to match the following:
+
+**Description:** Entitlement-key-date
+**Type:** SSL
+**Select file to upload:** Browse to the location where you saved the Entitlement key .pem file and select it.
+
+Repeat the above steps for the {redhat} CA Certificate (redhat-uep) and change the values to match the following:
+
+**Description:** redhat-uep
+**Type:** SSL
+**Select file to upload:** Browse to the location where you saved the {redhat} CA Certificate and select it.
+
+You now have imported the Entitlement certificate, the Entitlement key and the {redhat} CA into {productname} Server for use. Your outcome should look like the screen below:
+
+== Create Software Repositories
+
+[WARNING]
+====
+Use the output of repository URL’s obtained earlier from the subscription manager tool to create other repositories to which you are entitled. Mirror only the content which you need to manage your systems.
+====
+
+To mirror the software from the {redhat} CDN, you need to create custom channels and repositories in {productname} Server that are linked to the CDN with their respective URL. This will only work if you have entitlements to these products in your {redhat} Portal. To create these software repositories you need to perform the following actions.
+
+On your {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+
+// Maybe a screenshot could help, as the original guide.
+
+Click **Create Repository**. The following screen opens, where you can enter the required information to create the repository.
+
+// Maybe a screenshot could help, as the original guide.
+
+Fill in the fields with values, following the example below:
+
+**Repository Label:** rhel-7-server-rpms
+**Repository URL:** https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+**Has Signed Metadata?:** Uncheck (Uncheck for all Red Hat Enterprise Repositories)
+**SSL CA Certificate:** redhat-uep
+**SSL Client Certificate:** Entitlement-Cert-date
+**SSL Client Key:** Entitlement-Key-date
+
+Leave other filed with the default values.
+
+These steps need to be repeated for the Products / Repository URLs you define for your environment.
+
+== Create Software Channel Delivery
+
+Next step is to create corresponding channels to which you assign these repositories.
+
+On your {productname} Server {webui}, navigate to menu:Software[Manage > Channels].
+
+=== Parent Channels Example
+
+Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
+
+**Channel Name:** RHEL 7 x86_64
+**Channel Label:** rhel7-x86_64-server
+**Parent Channel:** None
+**Architecture:** x86_64
+**Repository Checksum Type:** sha1
+**Channel Summary:** RHEL 7 x86_64
+**Organization Sharing:** Public
+
+
+After you have filled in the values, click again **Create Channel**.
+
+Click the [guimenu]``Repositories`` tab, and mark the checkbox next to the appropriate repository, and then click btn:[Update repositories].
+
+// Add a screenshot
+
+Click the [guimenu]``Sync`` tab, and set your preferred recurring schedule for synchronization for this repository. Select btn:[Sync Now] to launch the synchronization immediately.
+
+[WARNING]
+====
+{RHEL} OS channels can grow to be very large. Thus it can take several hours to complete mirroring.
+====
+
+// add a screenshot
+
+=== Child Channels example
+
+Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
+
+**Channel Name:** RHEL 7 x86_64
+**Channel Label:** rhel7-x86_64-extras
+**Parent Channel:** rhel7-x86_64-server (from drop-down box)
+**Architecture:** x86_64
+**Repository Checksum Type:** sha1
+**Channel Summary:** RHEL 7 x86_64 Extras
+**Organization Sharing:** Public
+
+
+After you have filled in the values, click again **Create Channel**.
+
+Click the [guimenu]``Repositories`` tab, and mark the checkbox next to the appropriate repository, and then click btn:[Update repositories].
+
+// Add a screenshot
+
+Click the [guimenu]``Syn`` tab, and set your preferred recurring schedule for synchronization for this repository. You can also select btn:[Sync Now] to launch the synchronization immediately.
+
+[WARNING]
+====
+Some of the {RHEL} channels can grow to be very large. Thus it can take several hours to complete mirroring.
+====
+
+// add a screenshot
+
+== Activation key
+
+Now you can proceed to create the activation key in the {productname} Server {webui}, and assign appropriate channels to it.
+
+== Registration
+
+=== Add Client Tools channels
+
+ifeval::[{suma-content} == true]
+SUSE Manager subscriptions entitle everyone to the tools channels for {sleses} (also known as Red Hat Expanded Support or RES). Any Red Hat Enterprise Linux system should use these to create the proper bootstrap repository for either traditional or salt-minion connectivity.
+
+1. Add the corresponding required {slesesa} channels and allow it to synchronize from SUSE Customer Center.
+
+{slesesa} 6::
+* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI.
+
+{slesesa} 7::
+* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI.
+
+You can use [command]``mgr-sync`` to do it from CLI.
+
+// I am not sure we need this, as we instruct users to sync the repositories, including "os" (pool) and updates. I asked clarification from Donald.
+//2. Follow the instructions to synchronize your base media as a child repository for your distribution based on Red Hat Enterprise Linux, as explained in the SUSE Manager Wiki:
+//
+//https://wiki.microfocus.com/index.php/SUSE_Manager/Sync_RHEL_media
+
+3. Add the new channels to the activation key you created previously.
+
+endif::[]
+ifeval::[{uyuni-content} == true]
+
+// spacewalk-common-channels can't be used because centosX-uyuni-client requires centos7 channel as well, which a RHEL user would not need.
+
+1. On your {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+
+Click **Create Repository**. The following screen opens, where you can enter the required information to create the repository.
+
+Fill in the fields with values, following the example below:
+
+**Repository Label:** centos7-uyuni-client
+**Repository URL:** https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+**Has Signed Metadata?:** Uncheck
+
+Leave other filed with the default values.
+
+2. Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version and architecture):
+
+**Channel Name:** Uyuni Client Tools for CentOS 7 (x86_64)
+**Channel Label:** centos7-uyuni-client-x86_64
+**Parent Channel:** rhel7-x86_64-server
+**Architecture:** x86_64
+**Repository Checksum Type:** sha1
+**Channel Summary:** Uyuni Client Tools for CentOS 7 (x86_64)
+**Organization Sharing:** Public
+
+After you have filled in the values, click again btn:[Create Channel].
+
+Click the [guimenu]``Repositories`` tab, and mark the checkbox for ``centos7-uyuni-client``, and then click btn:[Update repositories].
+
+Click the [guimenu]``Sync``tab, and set your preferred recurring schedule for synchronization for this repository. Select btn:[Sync Now] to launch the synchronization immediately.
+
+3. Add the new channel to the activation key you created previously
+endif::[]
+
+=== Bootstrap Repository Creation
+
+Create a bootstrap repository for your Red Hat Enterprise Linux clients with
+
+----
+mgr-create-bootstrap-repo --with-custom-channels
+----
+
+Ensure that it completes without error.
+
+== Register {rhela} Clients
 
 When you are ready to register your {rhel} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -15,7 +15,7 @@ You must obtain support from either Red Hat or {suse} for all your RHEL systems.
 If you do not do this, you might be violating your terms with Red Hat.
 ====
 
-Ensure that your {productname} Server meets the requirements outlined at installation:hardware-requirements.adoc
+Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
 Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
 
@@ -25,14 +25,14 @@ To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn
 taskomatic.java.maxmemory=3072
 ----
 
-And restart Taskomatic:
+Restart Taskomatic:
 ----
 systemctl restart taskomatic
 ----
 
 == {rhel} Channel Management
 
-=== Adding {rhel} product from SCC
+=== Add {rhel} product from SCC
 
 Before you register {rhel} clients to your {productname} Server, check that you have the corresponding {rhel} product enabled, and the required channels are fully synchronized.
 
@@ -51,7 +51,7 @@ For more information on activation keys, see xref:client-configuration:clients-a
 
 There are two ways to check if a channel has finished synchronizing:
 
-* In the {productname}{webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
+* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
 This dialog displays a completion bar for each product when they are being synchronized.
 * You can also check the synchronization log file at the command prompt.
 Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
@@ -66,7 +66,7 @@ For {rhel} clients, packages are contained on the {rhel} installation media.
 Ensure you have loop-mounted the installation media, and added it as a child channel to the base {rhel} channel.
 ====
 
-=== Adding {rhel} media
+=== Add {rhel} media
 
 The base {rhel} software channel does not contain any packages.
 This is because {suse} does not provide {rhel} base media.

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -15,7 +15,7 @@ You must obtain support from either Red Hat or {suse} for all your RHEL systems.
 If you do not do this, you might be violating your terms with Red Hat.
 ====
 
-Ensure that your server meets the requirements outlined at installation:hardware-requirements.adoc
+Ensure that your {productname} Server meets the requirements outlined at installation:hardware-requirements.adoc
 
 Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
 
@@ -31,6 +31,42 @@ systemctl restart taskomatic
 ----
 
 == {rhel} Channel Management
+
+=== Adding {rhel} product from SCC
+
+Before you register {rhel} clients to your {productname} Server, check that you have the corresponding {rhel} product enabled, and the required channels are fully synchronized.
+
+You will also need an activation key associated with the {rhel} channel.
+For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+
+{rhel} 7::
+* Product: {rhel} 7
+* Mandatory channels: [systemitem]``rhel-x86_64-server-7`` , [systemitem]``res7-suse-manager-tools-x86_64`` , [systemitem]``res7-x86_64``
+
+
+{rhel} 6::
+* Product: {rhel} 6
+* Mandatory channels: [systemitem]``rhel-x86_64-server-6`` , [systemitem]``res6-suse-manager-tools-x86_64`` , [systemitem]``res6-x86_64``
+
+
+There are two ways to check if a channel has finished synchronizing:
+
+* In the {productname}{webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
+This dialog displays a completion bar for each product when they are being synchronized.
+* You can also check the synchronization log file at the command prompt.
+Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
+If you use this method, remember that base channels can contain multiple child channels.
+Each of the child channels will generate its own log during the synchronization progress.
+You will need to check all the base and child channel log files to be sure that the synchronization is complete.
+
+[IMPORTANT]
+====
+Missing packages will cause your registration to fail.
+For {rhel} clients, packages are contained on the {rhel} installation media.
+Ensure you have loop-mounted the installation media, and added it as a child channel to the base {rhel} channel.
+====
+
+=== Adding {rhel} media
 
 The base {rhel} software channel does not contain any packages.
 This is because {suse} does not provide {rhel} base media.
@@ -100,145 +136,14 @@ export URLGRABBER_DEBUG=DEBUG
 
 Check the output:
 ----
-/usr/bin/spacewalk-repo-sync --channel _<channel-label>_ --type yum
+/usr/bin/spacewalk-repo-sync --channel <channel-label> --type yum
 ----
 
 Disable debug mode:
 ----
-unset URLGRABBER_DEBUG``
+unset URLGRABBER_DEBUG
 ----
-
-
 
 == Register {rhel} Clients
 
-
-Before you register {rhel} clients to your {productname} Server, check that you have the corresponding {rhel} product enabled, and the required channels are fully synchronized.
-
-You will also need an activation key associated with the {rhel} channel.
-For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
-
-[IMPORTANT]
-====
-Missing packages will cause your registration to fail.
-For {rhel} clients, packages are contained on the {rhel} installation media.
-Ensure you have loop-mounted the installation media, and added it as a child channel to the base {rhel} channel.
-====
-
-
-{rhel} 7::
-* Product: {rhel} 7
-* Mandatory channels: [systemitem]``rhel-x86_64-server-7`` , [systemitem]``res7-suse-manager-tools-x86_64`` , [systemitem]``res7-x86_64``
-
-
-{rhel} 6::
-* Product: {rhel} 6
-* Mandatory channels: [systemitem]``rhel-x86_64-server-6`` , [systemitem]``res6-suse-manager-tools-x86_64`` , [systemitem]``res6-x86_64``
-
-
-There are two ways to check if a channel has finished synchronizing:
-
-* In the {productname}{webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
-This dialog displays a completion bar for each product when they are being synchronized.
-* You can also check the synchronization log file at the command prompt.
-Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
-If you use this method, remember that base channels can contain multiple child channels.
-Each of the child channels will generate its own log during the synchronization progress.
-You will need to check all the base and child channel log files to be sure that the synchronization is complete.
-
 When you are ready to register your {rhel} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
-
-
-
-
-
-////
-This is all duplicated content. LKB 2018-08-31
-
-.Procedure: Registering a bootstrap repository:
-
- . At the command prompt on the {productname} Server, as root, create a bootstrap repository for {rhel}:
-+
-----
-mgr-create-bootstrap-repo RHEL_activation_channel_key
-----
-+
-If you use a dedicated channel per RHEL version, specify it with the [literal]``--with-custom-channel`` option.
-
-. Rename [command]``bootstrap.sh`` to [command]``resversion-boostrap.sh``:
-+
-
-----
-cp bootstrap.sh res7-bootstrap.sh
-----
-
-
-== Register a Salt Client via Bootstrap
-
-
-The following procedure will guide you through registering a Salt client using the bootstrap script.
-
-.Procedure: Registration Using the Bootstrap Script
-. For your new client download the bootstrap script from the {productname} server:
-+
-
-----
-wget --no-check-certificate https://`server`/pub/bootstrap/res7-bootstrap.sh
-----
-. Add the appropriate res-gpg-pubkey-#####-#####.key to the `ORG_GPG_KEY` key parameter, comma delimited in your [command]``res7-bootstrap.sh`` script. These are located on your {productname} server at:
-+
-
-----
-http://`server`/pub/
-----
-. Make the [command]``res7-bootstrap.sh`` script executable and run it. This will install necessary Salt packages from the bootstrap repository and start the Salt client service:
-+
-
-----
-chmod +x res7-bootstrap.sh
-./res7-boostrap.sh
-----
-
-. From the {productname} {webui} select menu:Salt[Keys] and accept the new client's key.
-
-////
-
-
-////
-I'm fairly certain this isn't supported, which is why we took it out of the SLE instructions. LKB 2018-08-12
-
-== Manual Salt Client Registration
-
-
-The following procedure will guide you through the registration of a Salt client manually.
-
-
-. Add the bootstrap repository:
-+
-
-----
-yum-config-manager --add-repo https://`server`/pub/repositories/res/7/bootstrap
-----
-. Install the [package]#salt-minion# package:
-+
-
-----
-yum install salt-minion
-----
-. Edit the Salt client configuration file to point to the {productname} server:
-+
-
-----
-mkdir /etc/salt/minion.d
-echo "master:`server_fqdn`" > /etc/salt/minion.d/susemanager.conf
-----
-. Start the client service:
-+
-
-----
-systemctl start salt-minion
-----
-
-. From the {productname} {webui} select the menu:Salt[Keys] and accept the new client's key.
-
-////

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -1,0 +1,167 @@
+[[clients-sleses]]
+= Registering {sleses} Clients
+
+This section contains information about registering traditional and Salt clients running {sleses} operating systems ({slesesa} for the rest of the guide)
+
+{slesesa} clients can be initally based {rhel} or {centos}.
+
+[WARNING]
+====
+{slesesa} clients are also called sometimes RES or {redhat} {slesa})
+For {rhel} based clients tou are responsible for arranging access to {rhela} or {centos} base media repositories installation media.
+ifeval::[{suma-content} == true]
+You must obtain support from {suse} for all your {slesesa} systems.
+endif::[]
+ifeval::[{uyuni-content} == true]
+{suse} does not provide support for {slesesa} systems on Uyuni.
+endif::[]
+====
+
+== Server requirements
+
+Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
+
+Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
+
+To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+
+----
+taskomatic.java.maxmemory=3072
+----
+
+Restart Taskomatic:
+----
+systemctl restart taskomatic
+----
+
+== {slesesa} Channel Management
+
+[IMPORTANT]
+====
+Missing packages will cause your registration to fail.
+For {slesesa} clients, some required packages are contained on the {rhel} installation media or the {centos} installation media.
+Ensure you follow the whole procedure before trying to register any {slesa} client
+====
+
+=== Add {slesesa} product from SCC
+
+The {slesesa} product is provided by {scc}, including the client tools.
+
+Because the {slesesa} channels are particularly large, it can take up to 24 hours for an initial channel synchronization to complete.
+When you have completed the initial synchronization, we recommended you clone the channel before working with it.
+This provides you with a backup of the original synchronization data.
+
+Before you register {slesesa} clients to your {productname} Server, check that you have the corresponding {slesesa} product enabled, and the required channels are fully synchronized.
+
+You need to select two different sets of channels, one for {slesesa} and the other for the Client Tools.
+
+{slesesa} 6::
+* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools 
+* "RHEL Expanded Support 6" at the WebUI, or [systemitem]``res6-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
+
+// I suggest adding scripts
+
+{slesesa} 7::
+* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools 
+* "RHEL Expanded Support 7" at the WebUI, or [systemitem]``res7-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
+
+// I suggest adding scripts
+
+You can synchronize the channels with [command]``mgr-sync``.
+
+There are two ways to check if a channel has finished synchronizing:
+
+* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
+This dialog displays a completion bar for each product when they are being synchronized.
+* You can also check the synchronization log file at the command prompt.
+
+Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
+
+If you use this method, remember that base channels can contain multiple child channels.
+
+Each of the child channels will generate its own log during the synchronization progress.
+
+You will need to check all the base and child channel log files to be sure that the synchronization is complete.
+
+You will also need an activation key associated with the correct {slesesa} channels (6 or 7)
+
+For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+
+=== Add {rhel} or {centos} Media
+
+The Base {slesesa} channel does not contain any packages.
+
+This is because {suse} does not provide {rhel} or {centos} base media.
+
+You will need to obtain base media from {redhat} or {centos}, which you can then add as a child channel to the {slesesa} parent channel.
+
+The following procedure guides you through setup of the {rhel} or {centos} media as a {productname} channel.
+
+All packages on the media will be mirrored into a child channel located under the distribution name and architecture.
+
+.Procedure: Setting up a {rhel} or {centos} Channel
+
+. In the {productname} {webui}, navigate to menu:Channels[Manage Software Channels], and click btn:[Create Channel].
+. Fill in the channel details, and add the channel as a child to the corresponding {rhel} or {centos} distribution channel for your architecture.
+The base parent channel will not contain any packages.
+. Modify the associated activation key to include your new child channel.
+. At the command prompt, as root, copy your installation disk image to the [path]``/tmp`` directory.
+. Create a directory to contain the media content (you can replace [path]``/rhel`` with [path]``/centos`` if you are using {centos}
++
+----
+mkdir -p /srv/www/htdocs/pub/rhel
+----
+. Mount the ISO:
++
+----
+mount -o loop /tmp/name_of_iso /srv/www/htdocs/pub/rhel
+----
+. Synchronize the packages with [command]``spacewalk-repo-sync``:
++
+For {rhel} or {centos} 7:
++
+----
+spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/
+Repo URL: https://127.0.0.1/pub/rhel/
+Packages in repo:              [...]
+Packages already synced:       [...]
+Packages to sync:              [...]
+[...]
+----
++
+For {rhel} or {centos} 6:
++
+----
+spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/Server/
+Repo URL: https://127.0.0.1/pub/rhel/Server/
+Packages in repo:              [...]
+Packages already synced:       [...]
+Packages to sync:              [...]
+[...]
+----
+
+Sometimes, the [command]``spacewalk-repo-sync`` will stop running during a synchronization, which will give this error:
+----
+[Errno 256] No more mirrors to try.
+----
+
+If this occurs, you can run [command]``spacewalk-repo-sync`` in debugging mode to determine the error.
+
+Start debugging mode:
+----
+export URLGRABBER_DEBUG=DEBUG
+----
+
+Check the output:
+----
+/usr/bin/spacewalk-repo-sync --channel <channel-label> --type yum
+----
+
+Disable debug mode:
+----
+unset URLGRABBER_DEBUG
+----
+
+== Register {slesesa} Clients
+
+When you are ready to register your {slesesa} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].

--- a/suma-site.yml
+++ b/suma-site.yml
@@ -47,7 +47,9 @@ asciidoc:
     ipf: Itanium
     x86: x86
     x86_64: x86_64
+    centos: 'CentOS'
     rhel: 'Red Hat Enterprise Linux'
+    rhela: 'RHEL'
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
     rhnminrelease7: 'Red Hat Enterprise Linux Server 7'
     ubuntu: Ubuntu
@@ -65,6 +67,8 @@ asciidoc:
     scc: SUSE Customer Center
     sls: SUSE Linux Enterprise Server
     sle: SUSE Linux Enterprise
+    sleses: SUSE Linux Enterprise Server with Expanded Support
+    slesesa: Expanded Support
     slsa: SLES
     suse: SUSE
     slea: SLE

--- a/uyuni-site.yml
+++ b/uyuni-site.yml
@@ -39,7 +39,9 @@ asciidoc:
     ipf: Itanium
     x86: x86
     x86_64: x86_64
+    centos: 'CentOS'
     rhel: 'Red Hat Enterprise Linux'
+    rhela: 'RHEL'
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
     rhnminrelease7: 'Red Hat Enterprise Linux Server 7'
     ubuntu: Ubuntu
@@ -57,6 +59,8 @@ asciidoc:
     scc: SUSE Customer Center
     sls: SUSE Linux Enterprise Server
     sle: SUSE Linux Enterprise
+    sleses: SUSE Linux Enterprise Server with Expanded Support
+    slesesa: Expanded Support
     slsa: SLES
     suse: SUSE
     slea: SLE


### PR DESCRIPTION
- "Set up a Red Hat Enterprise Linux Client" was incorrect. That part described stuff about the server
- First we need to sync the product from SCC, so we have the base channel, then the media is imported.
- Separate the registration to its own section (I removed the commented content, which was about this, and it's now a link).


Addresses:
- [ ] https://github.com/SUSE/spacewalk/issues/9347
- [ ] https://github.com/SUSE/spacewalk/issues/9529