### PR TITLE
WIP: Rework ES/RHEL/CentOS doc

### DIFF
--- a/branding/pdf/entities.adoc
+++ b/branding/pdf/entities.adoc
@@ -8,11 +8,14 @@
 :x86: x86
 :x86_64: x86_64
 :centos: CentOS
+:redhat: Red Hat
 :rhel: Red Hat Enterprise Linux
 :rhela: RHEL
 :rhnminrelease6: Red Hat Enterprise Linux Server 6
 :rhnminrelease7: Red Hat Enterprise Linux Server 7
 :ubuntu: Ubuntu
+:opensuse: openSUSE
+:centos: CentOS
 :kickstart: Kickstart
 :productname:
 :productproxy: {productname} Proxy
@@ -47,7 +50,6 @@
 :rootuser: root
 :ruser: root
 :mdash: -
-:rhela: RHEL
 :mgradvtop: Advanced Topics Guide
 :mgrgetstart: Getting Started Guide
 :mgrrefguide: Reference Guide

--- a/branding/pdf/entities.adoc
+++ b/branding/pdf/entities.adoc
@@ -7,7 +7,9 @@
 :ipf : Itanium
 :x86: x86
 :x86_64: x86_64
+:centos: CentOS
 :rhel: Red Hat Enterprise Linux
+:rhela: RHEL
 :rhnminrelease6: Red Hat Enterprise Linux Server 6
 :rhnminrelease7: Red Hat Enterprise Linux Server 7
 :ubuntu: Ubuntu
@@ -31,6 +33,8 @@
 :scc: SUSE Customer Center
 :sls: SUSE Linux Enterprise Server
 :sle: SUSE Linux Enterprise
+:sleses: SUSE Linux Enterprise Server with Expanded Support
+:slesesa: Expanded Support
 :slsa: SLES
 :suse: SUSE
 :slea: SLE

--- a/modules/client-configuration/nav-client-config-guide.adoc
+++ b/modules/client-configuration/nav-client-config-guide.adoc
@@ -19,6 +19,7 @@ ifndef::backend-pdf[]
 *** xref:disconnected-setup.adoc[Disconnected Setup]
 // Non-SUSE Clients
 ** xref:non-suse-clients.adoc[Other Clients]
+*** xref:clients-sleses.adoc[Expanded Support Clients]
 *** xref:clients-rh.adoc[Red Hat Clients]
 *** xref:clients-centos.adoc[CentOS Clients]
 *** xref:clients-ubuntu.adoc[Ubuntu Clients]
@@ -88,6 +89,8 @@ include::modules/client-configuration/pages/disconnected-setup.adoc[leveloffset=
 // Non-SUSE Clients
 
 include::modules/client-configuration/pages/non-suse-clients.adoc[leveloffset=+1]
+
+include::modules/client-configuration/pages/clients-sleses.adoc[leveloffset=+2]
 
 include::modules/client-configuration/pages/clients-rh.adoc[leveloffset=+2]
 

--- a/modules/client-configuration/pages/clients-centos.adoc
+++ b/modules/client-configuration/pages/clients-centos.adoc
@@ -68,7 +68,6 @@ In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and
 
 . In the [guimenu]``Repositories`` tab, navigate to the [guimenu]``Sync`` subtab, and click btn:[Sync Now].
 You can also create a regular synchronization schedule on this page.
-endif::[]
 
 == Create an activation key
 

--- a/modules/client-configuration/pages/clients-centos.adoc
+++ b/modules/client-configuration/pages/clients-centos.adoc
@@ -5,11 +5,11 @@ This section contains information about registering traditional and Salt clients
 
 [WARNING]
 ====
-{centos} Clients are completely based on {centos} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesa})
+{centos} Clients are completely based on {centos} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesesa})
 You are responsible for arranging access to {centos} base media repositories and {centos} installation media, as well as connecting {productname} Server to {centos} Content Delivery Network
 ifeval::[{suma-content} == true]
 {suse} does not provide support for {centos} operating system.
-Currently {centos} works with {productname} but support is not provided
+Currently {productname} allows managing {centos} but support is not provided.
 endif::[]
 ====
 
@@ -34,29 +34,6 @@ systemctl restart taskomatic
 
 .Procedure: Add the Channels and Repositories
 
-ifeval::[{suma-content} == true]
-SUSE Manager subscriptions entitle everyone to the tools channels for {sleses} (also known as Red Hat Expanded Support or RES). Any Red Hat Enterprise Linux system should use these to create the proper bootstrap repository for either traditional or salt-minion connectivity.
-
-1. Add the corresponding required {slesesa} channels and allow it to synchronize from SUSE Customer Center.
-
-{slesesa} 6::
-* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI.
-
-{slesesa} 7::
-* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI.
-
-You can use [command]``mgr-sync`` to do it from CLI.
-
-// I am not sure we need this, as we instruct users to sync the repositories, including "os" (pool) and updates. I asked clarification from Donald.
-//2. Follow the instructions to synchronize your base media as a child repository for your distribution based on Red Hat Enterprise Linux, as explained in the SUSE Manager Wiki:
-//
-//https://wiki.microfocus.com/index.php/SUSE_Manager/Sync_RHEL_media
-
-3. Add the new channels to the activation key you created previously.
-
-endif::[]
-
-ifeval::[{uyuni-content} == true]
 The [package]``spacewalk-utils`` package contains a number of command line tools required for client administration, including [command]``spacewalk-common-channels`` tool.
 
 ifeval::[{suma-content} == true]
@@ -72,20 +49,26 @@ At the command prompt on the {productname} Server, as root, install the [package
 zypper in spacewalk-utils
 ----
 
+// Because of the way mgr-create-bootstrap-repo works and because we don't have CentOS products at SCC, SUSE Manager users MUST use the same procedure as at Uyuni
+// They CANNOT use RES Client Tools.
+
 Add the {centos} base, updates, and client channels using the [command]``spacewalk-common-channels`` script (adapt to your CentOS version and architecture):
 ----
 spacewalk-common-channels -a x86_64 centos7 centos7-uyuni-client centos7-uyuni-client
 ----
 
+[IMPORTANT]
+====
+The Client Tools that [command]``spacewalk-common-channels`` adds come from {uyuni} and not from {suse}
+====
+
 .Procedure: Syncronize {centos} repositories
 
-In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and select the base channel you want to synchronize.
+In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and for each {centos} channel, ckick on it.
 
 . In the [guimenu]``Repositories`` tab, navigate to the [guimenu]``Sync`` subtab, and click btn:[Sync Now].
 You can also create a regular synchronization schedule on this page.
 endif::[]
-
-When you have prepared you {productname} Server, you can install your {centos} client using your preferred installation media and method.
 
 == Create an activation key
 

--- a/modules/client-configuration/pages/clients-centos.adoc
+++ b/modules/client-configuration/pages/clients-centos.adoc
@@ -1,158 +1,110 @@
 [[clients-centos]]
 = Registering {centos} Clients
 
-
 This section contains information about registering traditional and Salt clients running {centos} operating systems.
 
+[WARNING]
+====
+{centos} Clients are completely based on {centos} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesa})
+You are responsible for arranging access to {centos} base media repositories and {centos} installation media, as well as connecting {productname} Server to {centos} Content Delivery Network
+ifeval::[{suma-content} == true]
+{suse} does not provide support for {centos} operating system.
+Currently {centos} works with {productname} but support is not provided
+endif::[]
+====
 
+== Server requirements
 
-== Set up a {centos} Client
+Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
-The [package]``spacewalk-utils`` package contains a number of upstream command line tools required for client administration.
-You will also require the [command]``spacewalk-common-channels`` tool.
+Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
+
+To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+
+----
+taskomatic.java.maxmemory=3072
+----
+
+Restart Taskomatic:
+----
+systemctl restart taskomatic
+----
+
+== {centos} Channel and Repository Management
+
+.Procedure: Add the Channels and Repositories
+
+ifeval::[{suma-content} == true]
+SUSE Manager subscriptions entitle everyone to the tools channels for {sleses} (also known as Red Hat Expanded Support or RES). Any Red Hat Enterprise Linux system should use these to create the proper bootstrap repository for either traditional or salt-minion connectivity.
+
+1. Add the corresponding required {slesesa} channels and allow it to synchronize from SUSE Customer Center.
+
+{slesesa} 6::
+* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI.
+
+{slesesa} 7::
+* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI.
+
+You can use [command]``mgr-sync`` to do it from CLI.
+
+// I am not sure we need this, as we instruct users to sync the repositories, including "os" (pool) and updates. I asked clarification from Donald.
+//2. Follow the instructions to synchronize your base media as a child repository for your distribution based on Red Hat Enterprise Linux, as explained in the SUSE Manager Wiki:
+//
+//https://wiki.microfocus.com/index.php/SUSE_Manager/Sync_RHEL_media
+
+3. Add the new channels to the activation key you created previously.
+
+endif::[]
+
+ifeval::[{uyuni-content} == true]
+The [package]``spacewalk-utils`` package contains a number of command line tools required for client administration, including [command]``spacewalk-common-channels`` tool.
+
+ifeval::[{suma-content} == true]
+[WARNING]
+====
 Keep in mind {suse} only provides support for [command]``spacewalk-clone-by-date`` and [command]``spacewalk-manage-channel-lifecycle`` tools.
+====
+endif::[]
 
-The [path]``/etc/rhn/spacewalk-common-channels.ini`` configuration file must contain the channel references you want to add.
-If a channel is not listed, check the latest version for updates: https://github.com/spacewalkproject/spacewalk/tree/master/utils
+At the command prompt on the {productname} Server, as root, install the [package]``spacewalk-utils`` package:
 
-You will also need an activation key associated with the {centos} channel.
-For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
-
-
-.Procedure: Adding Channels and Repositories
-
-. At the command prompt on the {productname} Server, as root, install the [package]``spacewalk-utils`` package:
-+
 ----
 zypper in spacewalk-utils
 ----
-. Add the {centos} base, updates, and client channels using the [command]``spacewalk-common-channels`` script:
-+
+
+Add the {centos} base, updates, and client channels using the [command]``spacewalk-common-channels`` script (adapt to your CentOS version and architecture):
 ----
-spacewalk-common-channels -u admin -p `secret` -a x86_64 'centos7'
-spacewalk-common-channels -u admin -p `secret` -a x86_64 'centos7-updates'
-spacewalk-common-channels -u admin -p `secret` -a x86_64 'centos7-uyuni-client-x86_64'
+spacewalk-common-channels -a x86_64 centos7 centos7-uyuni-client centos7-uyuni-client
 ----
 
-.Procedure: Synchronizing {centos} Clients
+.Procedure: Syncronize {centos} repositories
 
-. In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and select the base channel you want to synchronize.
+In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and select the base channel you want to synchronize.
+
 . In the [guimenu]``Repositories`` tab, navigate to the [guimenu]``Sync`` subtab, and click btn:[Sync Now].
 You can also create a regular synchronization schedule on this page.
+endif::[]
 
 When you have prepared you {productname} Server, you can install your {centos} client using your preferred installation media and method.
 
-.Procedure: Setting up a {centos} Client
+== Create an activation key
 
-. At the command prompt, copy all relevant GPG keys to [path]``/srv/www/htdocs/pub``.
-If you intend to use a bootstrap script to register your client, you can add the GPG keys to your bootstrap script.
-. Check that the client machine can resolve itself and your {productname} Server using DNS.
-. Check that there is an entry in [path]``/etc/hosts`` for the real IP address of the client.
-. Create an activation key called `centos7` on the {productname} Server that points to the correct parent and child channels, including the {centos} base repository, updates, and client channels.
+You will also need an activation key associated with the {centos} channels (6 or 7) created on the previous setp
+
+For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+
+ifeval::[{uyuni-content} == true]
+== Trust GPG keys at the clients
+
+The GPG key for Uyuni CentOS Client Tools is not trusted by default by CentOS.
+
+The systems will bootstrap without the GPG key being trusted, but will not be able to install new client tool packages or updated them.
+
+This can be fixed by adding the key ``uyuni-gpg-pubkey-0d20833e.key`` to all the CentOS bootscrap scripts at variable ``ORG_GPG_KEY=``. If you already have other keys there, you can keep them.
+
+For systems bootstrapped from WebUI, a salt state should be created to trust the key, then the state can be assigned to the organization, and finally it can be used using an Activation Key and the Configuration Channels to deploy the change to the clients.
+endif::[]
+
+== Register {centos} Clients
 
 When you are ready to register your {centos} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
-
-
-////
-This is all duplicated content. LKB 2018-08-31
-
-Now prepare the bootstrap script.
-
-[[proc.bp.expanded-support.centos-repos.trad.bsscript]]
-.Procedure: Preparing the Bootstrap Script
-. Create/edit your bootstrap script to correctly reflect the following:
-+
-
-----
-# can be edited, but probably correct (unless created during initial install):
-
-# NOTE: ACTIVATION_KEYS *must* be used to bootstrap a client machine.
-
-ACTIVATION_KEYS=1-centos7
-
-ORG_GPG_KEY=res.key,RPM-GPG-KEY-CentOS-7,suse-307E3D54.key,suse-9C800ACA.key,RPM-GPG-KEY-spacewalk-2015
-
-FULLY_UPDATE_THIS_BOX=0
-
-yum clean all
-# Install the prerequisites
-yum -y install yum-rhn-plugin rhn-setup
-----
-. Add the following lines to the bottom of your script, (just before `echo "`-bootstrap complete -`"`):
-+
-
-----
-# This section is for commands to be executed after registration
-mv /etc/yum.repos.d/Cent* /root/
-yum clean all
-chkconfig rhnsd on
-chkconfig osad on
-service rhnsd restart
-service osad restart
-----
-. Continue by following normal bootstrap procedures to bootstrap the new client.
-
-
-[[bp.expanded-support.centos_salt]]
-== Registering CentOS Salt Clients with {productname}
-
-
-The following procedure will guide you through registering a CentOS client.
-
-.Support for CentOS Patches
-[WARNING]
-====
-
-CentOS uses patches originating from CentOS is not officially supported by {suse}
-.
-See the matrix of {productname} clients on the main page of the {productname} wiki, linked from the [ref]_Quick Links_ section: https://wiki.microfocus.com/index.php?title=SUSE_Manager
-
-====
-
-////
-
-
-////
-I'm fairly certain this isn't supported, which is why we took it out of the SLE instructions. LKB 2018-08-12
-
-
-.Procedure: Register a CentOS 7 Client
-. Add the Open Build Service repo for Salt:
-+
-
-----
-yum-config-manager --add-repo http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/RHEL_7/
-----
-. Import the repo key:
-+
-
-----
-rpm --import http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/RHEL_7/repodata/repomd.xml.key
-----
-. Check if there is a different repository that contains Salt. If there is more than one repository listed disable the repository that contains Salt apart from the OBS one.
-+
-
-----
-yum list --showduplicates salt
-----
-. Install the Salt client:
-+
-
-----
-yum install salt salt-minion
-----
-. Change the Salt configuration to point to the {productname} server:
-+
-
-----
-mkdir -p /etc/salt/minion.d
-echo "master:`server_fqdn`" > /etc/salt/minion.d/susemanager.conf
-----
-. Restart the client
-+
-
-----
-systemctl restart salt-minion
-----
-. Proceed to menu:Main Menu[Salt > Keys] from the {webui} and accept the client's key.
-////

--- a/modules/client-configuration/pages/clients-centos.adoc
+++ b/modules/client-configuration/pages/clients-centos.adoc
@@ -101,9 +101,10 @@ ifeval::[{uyuni-content} == true]
 By default, {centos} does not trust the GPG key for {productname} {centos} client tools.
 
 The clients can be successfully bootstrapped without the GPG key being trusted.
+
 However, they will not be able to install new client tool packages or update them.
 
-If this occurs, add this key to the [systemitem]``ORG_GPG_KEY=`` parameter in all {centos} bootstrap scripts:
+To fix this, add this key to the [systemitem]``ORG_GPG_KEY=`` parameter in all {centos} bootstrap scripts:
 ----
 uyuni-gpg-pubkey-0d20833e.key
 ----

--- a/modules/client-configuration/pages/clients-centos.adoc
+++ b/modules/client-configuration/pages/clients-centos.adoc
@@ -3,23 +3,30 @@
 
 This section contains information about registering traditional and Salt clients running {centos} operating systems.
 
-[WARNING]
+[IMPORTANT]
 ====
-{centos} Clients are completely based on {centos} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesesa})
-You are responsible for arranging access to {centos} base media repositories and {centos} installation media, as well as connecting {productname} Server to {centos} Content Delivery Network
+{centos} clients are based on {centos} and are unrelated to {sleses}, RES, {redhat}, or {slesesa}.
+You are responsible for arranging access to {centos} base media repositories and {centos} installation media, as well as connecting {productname} Server to the {centos} content delivery network.
+====
+
 ifeval::[{suma-content} == true]
-{suse} does not provide support for {centos} operating system.
-Currently {productname} allows managing {centos} but support is not provided.
-endif::[]
+
+[IMPORTANT]
+====
+{suse} does not provide support for {centos} operating systems.
+{productname} allows you to manage {centos} clients, but support is not provided.
 ====
 
-== Server requirements
+endif::[]
 
-Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
-Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
 
-To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+== Server Requirements
+
+Before you begin, check that your {productname} Server meets the requirements at xref:installation:hardware-requirements.adoc[].
+
+Taskomatic uses one CPU core, and requires at least 3072{nbsp}MB of RAM.
+To ensure that taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, and add this line:
 
 ----
 taskomatic.java.maxmemory=3072
@@ -30,63 +37,88 @@ Restart Taskomatic:
 systemctl restart taskomatic
 ----
 
-== {centos} Channel and Repository Management
 
-.Procedure: Add the Channels and Repositories
 
-The [package]``spacewalk-utils`` package contains a number of command line tools required for client administration, including [command]``spacewalk-common-channels`` tool.
+== Channel and Repository Management
+
+The [package]``spacewalk-utils`` package contains a number of command line tools required for client administration, including the [command]``spacewalk-common-channels`` tool.
+
 
 ifeval::[{suma-content} == true]
-[WARNING]
+
+[IMPORTANT]
 ====
-Keep in mind {suse} only provides support for [command]``spacewalk-clone-by-date`` and [command]``spacewalk-manage-channel-lifecycle`` tools.
+{suse} only provides support for [command]``spacewalk-clone-by-date`` and [command]``spacewalk-manage-channel-lifecycle`` tools.
 ====
+
 endif::[]
 
-At the command prompt on the {productname} Server, as root, install the [package]``spacewalk-utils`` package:
 
+
+.Procedure: Adding Channels and Repositories
+. At the command prompt on the {productname} Server, as root, install the [package]``spacewalk-utils`` package:
++
 ----
 zypper in spacewalk-utils
 ----
 
 // Because of the way mgr-create-bootstrap-repo works and because we don't have CentOS products at SCC, SUSE Manager users MUST use the same procedure as at Uyuni
 // They CANNOT use RES Client Tools.
-
-Add the {centos} base, updates, and client channels using the [command]``spacewalk-common-channels`` script (adapt to your CentOS version and architecture):
+. Add the {centos} base, updates, and client channels, specifying the {centos} version and architecture:
++
 ----
-spacewalk-common-channels -a x86_64 centos7 centos7-uyuni-client centos7-uyuni-client
+spacewalk-common-channels -a x86_64 centos7 \
+centos7-uyuni-client centos7-uyuni-client
 ----
 
-[IMPORTANT]
+[NOTE]
 ====
-The Client Tools that [command]``spacewalk-common-channels`` adds come from {uyuni} and not from {suse}
+The client tools channel provided by [command]``spacewalk-common-channels`` is sourced from {uyuni} and not from {suse}.
 ====
 
-.Procedure: Syncronize {centos} repositories
 
-In the {productname} {webui}, navigate to menu:Main Menu[Software > Manage], and for each {centos} channel, ckick on it.
 
+.Procedure: Synchronizing {centos} repositories
+
+. In the {productname} {webui}, navigate to menu:Software[Manage], and check every {centos} channel.
 . In the [guimenu]``Repositories`` tab, navigate to the [guimenu]``Sync`` subtab, and click btn:[Sync Now].
 You can also create a regular synchronization schedule on this page.
 
-== Create an activation key
 
-You will also need an activation key associated with the {centos} channels (6 or 7) created on the previous setp
+
+== Create an Activation Key
+
+You will need to create an activation key that is associated with your {centos} channels.
 
 For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
 
+
+
 ifeval::[{uyuni-content} == true]
-== Trust GPG keys at the clients
 
-The GPG key for Uyuni CentOS Client Tools is not trusted by default by CentOS.
+== Trust GPG Keys on Clients
 
-The systems will bootstrap without the GPG key being trusted, but will not be able to install new client tool packages or updated them.
+By default, {centos} does not trust the GPG key for {productname} {centos} client tools.
 
-This can be fixed by adding the key ``uyuni-gpg-pubkey-0d20833e.key`` to all the CentOS bootscrap scripts at variable ``ORG_GPG_KEY=``. If you already have other keys there, you can keep them.
+The clients can be successfully bootstrapped without the GPG key being trusted.
+However, they will not be able to install new client tool packages or update them.
 
-For systems bootstrapped from WebUI, a salt state should be created to trust the key, then the state can be assigned to the organization, and finally it can be used using an Activation Key and the Configuration Channels to deploy the change to the clients.
+If this occurs, add this key to the [systemitem]``ORG_GPG_KEY=`` parameter in all {centos} bootstrap scripts:
+----
+uyuni-gpg-pubkey-0d20833e.key
+----
+
+ You do not need to delete any previously stored keys.
+
+If you are boostrapping clients from the {productname} {webui}, you will need to use a salt state to trust the key.
+Create the salt state and assign it to the organization.
+You can then use an activation key and configuration channels to deploy the key to the clients.
+
 endif::[]
 
-== Register {centos} Clients
 
-When you are ready to register your {centos} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
+
+== Register Clients
+
+{centos} clients are registered in the same way as all other clients.
+For more information, see xref:client-configuration:registration-overview.adoc[].

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -257,6 +257,103 @@ Ensure you use the correct {rhela} version:
 
 endif::[]
 
+== Optional: Disable {rhel} subscription-manager yum plugins
+
+.Procedure: Create a configuration salt state to deploy the configuration file.
+
+. On the {productname} Server {webui}, navigate to menu:Configuration[Channels].
+. Click btn:[Create State Channel]
+* In the [guimenu]``Name`` field, type [systemitem]``subscription-manager: disable yum plugins``.
+* In the [guimenu]``Label`` field, type [systemitem]``subscription-manager-disable-yum-plugins``.
+* In the [guimenu]``Description`` field, type [systemitem]``subscription-manager: disable yum plugins``.
+* In the [guimenu]``SLS Contents`` field, leave it empty.
+. Click btn:[Create Config Channel]
+. Click btn:[Create Configuration File]
+* In the [guimenu]``Filename/Path``` field type [systemitem]``/etc/yum/pluginconf.d/subscription-manager.conf``.
+* In the [guimenu]``File Contents``` field type:
+----
+[main]
+enabled=0
+----
+. Click btn:[Create Configuration File]
+. Take note of the value of the field [guimenu]``Salt Filesystem Path```.
+. Click on the name of the Configuration Channel.
+. Click on [guimenu]``View/Edit 'init.sls' File``
+* In the [guimenu]``File Contents`` field, type:
+----
+configure_subscription-manager-disable-yum-plugins:
+  cmd.run:
+    - name: subscription-manager config --rhsm.auto_enable_yum_plugins=0
+    - watch:
+      - file: /etc/yum/pluginconf.d/subscription-manager.conf
+  file.managed:
+    - name: /etc/yum/pluginconf.d/subscription-manager.conf
+    - source: salt:///etc/yum/pluginconf.d/subscription-manager.conf
+----
+. Click btn:[Update Configuration File]
+
+.Procedure: Create a system group for RHEL systems
+
+. On the {productname} Server {webui}, navigate to menu:Systems[System Groups].
+. Click btn:[Create Group]
+* In the [guimenu]``Name`` field, type [systemitem]``rhel-systems``.
+* In the [guimenu]``Description`` field, type [systemitem]``All RHEL systems``.
+. Click btn:[Create Group]
+. Click [guimenu]``States`` tab
+. Click [guimenu]``Configuration Channels`` tab
+. Type [systemitem]``subscription-manager: disable yum plugins`` at the search box.
+. Click btn:[Search] and the state will appear.
+. Click the checkbox for the state at the [systemitem]``Assign`` column.
+. Click btn:[Save changes]
+. Click btn:[Confirm]
+
+If you already have RHEL systems added to ${productname}, assign them to the new system group, and then apply the highstate.
+
+.Procedure: Add the system group to your RHEL activation keys.
+
+You need to modify the activation keys you used for RHEL systems to include the system group created above.
+
+. On the {productname} Server {webui}, navigate to menu:Systems[Activation Keys].
+. For each the Activation Keys you used for RHEL systems, click on it and:
+. Navigate to the [guimenu]``Groups`` tab, and theb [guimenu]``Join`` subtab.
+. Check [systemitem]``Select rhel-systems```
+. Click btn:[Join Selected Groups]
+
+== Trust GPG Keys on Clients
+
+ifeval::[{suma-content} == true]
+By default, {rhel} does not trust the GPG key for {productname} {slesesa} client tools.
+endif::[]
+ifeval::[{uyuni-content} == true]
+By default, {rhel} does not trust the GPG key for {productname} {centos} client tools.
+endif::[]
+
+The clients can be successfully bootstrapped without the GPG key being trusted.
+
+However, they will not be able to install new client tool packages or update them.
+
+If this occurs, add this key to the [systemitem]``ORG_GPG_KEY=`` parameter in all {rhel} bootstrap scripts:
+
+ifeval::[{suma-content} == true]
+----
+sle12-gpg-pubkey-39db7c82.key
+----
+endif::[]
+ifeval::[{uyuni-content} == true]
+----
+uyuni-gpg-pubkey-0d20833e.key
+----
+endif::[]
+
+You do not need to delete any previously stored keys.
+
+If you are boostrapping clients from the {productname} {webui}, you will need to use a salt state to trust the key.
+Create the salt state and assign it to the organization.
+You can then use an activation key and configuration channels to deploy the key to the clients.
+
+endif::[]
+
+.Procedure: Adding Client Tools Channels
 
 
 == Register Clients

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -269,7 +269,7 @@ endif::[]
 * In the [guimenu]``SLS Contents`` field, leave it empty.
 . Click btn:[Create Config Channel]
 . Click btn:[Create Configuration File]
-* In the [guimenu]``Filename/Path``` field type [systemitem]``/etc/yum/pluginconf.d/subscription-manager.conf``.
+* In the [guimenu]``Filename/Path`` field type [systemitem]``/etc/yum/pluginconf.d/subscription-manager.conf``.
 * In the [guimenu]``File Contents``` field type:
 ----
 [main]

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -40,6 +40,8 @@ To avoid disruption, you will need to repeat this process at the end of every su
 It runs locally to track installed products and subscriptions.
 Clients must be registered with the subscription manager to obtain certificates.
 
+
+
 .Procedure: Registering Clients to Subscription Manager
 
 . On the client system, at the command prompt, register with the subscription manager tool:
@@ -117,6 +119,8 @@ This allows you to mirror only the content you need to manage your clients.
 You can only create custom versions of {redhat} repositories if you have the correct entitlements in your {redhat} Portal.
 ====
 
+
+
 .Procedure: Creating Custom Repositories
 
 . On the {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
@@ -134,6 +138,8 @@ For example, [systemitem]``https://cdn.redhat.com/content/dist/rhel/server/7/7Se
 
 
 When you have created the custom repositories, you can create corresponding custom channels.
+
+
 
 .Procedure: Creating Custom Channels
 
@@ -257,9 +263,17 @@ Ensure you use the correct {rhela} version:
 
 endif::[]
 
-== Optional: Disable {rhel} subscription-manager yum plugins
+You can choose to disable the {rhel} subscription-manager yum plugins.
+// Explain the use case.
 
-.Procedure: Create a configuration salt state to deploy the configuration file.
+The yum plugins are disabled with a configuration Salt state.
+
+.Procedure: Creating a Salt State to Deploy Configuration Files
+
+[NOTE]
+====
+This procedure is optional.
+====
 
 . On the {productname} Server {webui}, navigate to menu:Configuration[Channels].
 . Click btn:[Create State Channel]
@@ -292,7 +306,9 @@ configure_subscription-manager-disable-yum-plugins:
 ----
 . Click btn:[Update Configuration File]
 
-.Procedure: Create a system group for RHEL systems
+
+
+.Procedure: Creating a System Group for {rhel} Clients
 
 . On the {productname} Server {webui}, navigate to menu:Systems[System Groups].
 . Click btn:[Create Group]
@@ -309,7 +325,9 @@ configure_subscription-manager-disable-yum-plugins:
 
 If you already have RHEL systems added to ${productname}, assign them to the new system group, and then apply the highstate.
 
-.Procedure: Add the system group to your RHEL activation keys.
+
+
+.Procedure: Adding the System Group to Activation Keys
 
 You need to modify the activation keys you used for RHEL systems to include the system group created above.
 
@@ -352,6 +370,8 @@ Create the salt state and assign it to the organization.
 You can then use an activation key and configuration channels to deploy the key to the clients.
 
 endif::[]
+
+
 
 .Procedure: Adding Client Tools Channels
 

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -99,10 +99,8 @@ This requires three entries: one each for the entitlement certificate, the entit
 // put the screenshot here as a result. LKB
 
 
-// Lana, you're up to here! 2019-09-27
 
 == Repository Management
-
 
 
 You can use the subscription manager tool to get the URLs of the repositories you want to mirror:
@@ -111,168 +109,162 @@ You can use the subscription manager tool to get the URLs of the repositories yo
 subscription-manager repos
 ----
 
+You can use these repository URLs to create custom repositories.
+This allows you to mirror only the content you need to manage your clients.
 
-== Create Software Repositories
-
-[WARNING]
+[IMPORTANT]
 ====
-Use the output of repository URL’s obtained earlier from the subscription manager tool to create other repositories to which you are entitled. Mirror only the content which you need to manage your systems.
-====
-
-To mirror the software from the {redhat} CDN, you need to create custom channels and repositories in {productname} Server that are linked to the CDN with their respective URL. This will only work if you have entitlements to these products in your {redhat} Portal. To create these software repositories you need to perform the following actions.
-
-On your {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
-
-// Maybe a screenshot could help, as the original guide.
-
-Click **Create Repository**. The following screen opens, where you can enter the required information to create the repository.
-
-// Maybe a screenshot could help, as the original guide.
-
-Fill in the fields with values, following the example below:
-
-* **Repository Label:** rhel-7-server-rpms
-* **Repository URL:** https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
-* **Has Signed Metadata?:** Uncheck (Uncheck for all Red Hat Enterprise Repositories)
-* **SSL CA Certificate:** redhat-uep
-* **SSL Client Certificate:** Entitlement-Cert-date
-* **SSL Client Key:** Entitlement-Key-date
-
-Leave other filed with the default values.
-
-These steps need to be repeated for the Products / Repository URLs you define for your environment.
-
-== Create Software Channel Delivery
-
-Next step is to create corresponding channels to which you assign these repositories.
-
-On your {productname} Server {webui}, navigate to menu:Software[Manage > Channels].
-
-=== Parent Channels Example
-
-Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
-
-* **Channel Name:** RHEL 7 x86_64
-* **Channel Label:** rhel7-x86_64-server
-* **Parent Channel:** None
-* **Architecture:** x86_64
-* **Repository Checksum Type:** sha1
-* **Channel Summary:** RHEL 7 x86_64
-* **Organization Sharing:** Public
-
-
-After you have filled in the values, click again **Create Channel**.
-
-Click the [guimenu]``Repositories`` tab, and mark the checkbox next to the appropriate repository, and then click btn:[Update repositories].
-
-// Add a screenshot
-
-Click the [guimenu]``Sync`` tab, and set your preferred recurring schedule for synchronization for this repository. Select btn:[Sync Now] to launch the synchronization immediately.
-
-[WARNING]
-====
-{rhel} OS channels can grow to be very large. Thus it can take several hours to complete mirroring.
+You can only create custom versions of {redhat} repositories if you have the correct entitlements in your {redhat} Portal.
 ====
 
-// add a screenshot
+.Procedure: Creating Custom Repositories
 
-=== Child Channels example
+. On the {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+. Click btn:[Create Repository] and set these parameters for the entitlement certificate:
+* In the [guimenu]``Repository Label`` field, type [systemitem]``rhel-7-server-rpms``.
+* In the [guimenu]``Repository URL`` field, type the URL of the repository to mirror.
+For example, [systemitem]``https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/``.
+* In the [guimenu]``Has Signed Metadata?`` field, uncheck all Red Hat Enterprise Repositories.
+* In the [guimenu]``SSL CA Certificate`` field, select [systemitem]``redhat-uep``.
+* In the [guimenu]``SSL Client Certificate`` field, select [systemitem]``Entitlement-Cert-date``.
+* In the [guimenu]``SSL Client Key`` field, select [systemitem]``Entitlement-Key-date``.
+* Leave all other fields as the default values.
+. Click btn:[Create Repository]
+. Repeat for every repository you want to define.
 
-Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
 
-* **Channel Name:** RHEL 7 x86_64
-* **Channel Label:** rhel7-x86_64-extras
-* **Parent Channel:** rhel7-x86_64-server (from drop-down box)
-* **Architecture:** x86_64
-* **Repository Checksum Type:** sha1
-* **Channel Summary:** RHEL 7 x86_64 Extras
-* **Organization Sharing:** Public
+When you have created the custom repositories, you can create corresponding custom channels.
+
+.Procedure: Creating Custom Channels
+
+. On the {productname} Server {webui}, navigate to menu:Software[Manage > Channels].
+. Click btn:[Create Channel] and set these parameters for the entitlement certificate.
+Ensure you use the correct {rhela} version:
+* In the [guimenu]``Channel Name`` field, type [systemitem]``RHEL 7 x86_64``.
+* In the [guimenu]``Channel Label`` field, type [systemitem]``rhel7-x86_64-server``.
+* In the [guimenu]``Parent Channel`` field, select [systemitem]``None``.
+* In the [guimenu]``Architecture`` field, select [systemitem]``x86_64``.
+* In the [guimenu]``Repository Checksum Type`` field, select [systemitem]``sha1``.
+* In the [guimenu]``Channel Summary`` field, type [systemitem]``RHEL 7 x86_64``.
+* In the [guimenu]``Organization Sharing`` field, select [systemitem]``Public``.
+. Click btn:[Create Channel].
+. Navigate to the [guimenu]``Repositories`` tab, check the appropriate repository, and click btn:[Update repositories].
+. OPTIONAL: Navigate to the [guimenu]``Sync`` tab to set a recurring schedule for synchronization of this repository.
+. Click btn:[Sync Now] to begin synchronization immediately.
 
 
-After you have filled in the values, click again **Create Channel**.
-
-Click the [guimenu]``Repositories`` tab, and mark the checkbox next to the appropriate repository, and then click btn:[Update repositories].
-
-// Add a screenshot
-
-Click the [guimenu]``Syn`` tab, and set your preferred recurring schedule for synchronization for this repository. You can also select btn:[Sync Now] to launch the synchronization immediately.
-
-[WARNING]
+[NOTE]
 ====
-Some of the {rhel} channels can grow to be very large. Thus it can take several hours to complete mirroring.
+{rhel} channels can be very large.
+Synchronization can sometimes take several hours.
 ====
 
-// add a screenshot
 
-== Activation key
+When you have created the custom channels and synchronized them with the repositories, you can create child channels.
 
-Now you can proceed to create the activation key in the {productname} Server {webui}, and assign appropriate channels to it.
+.Procedure: Creating Child Channels
 
-== Registration
+. On the {productname} Server {webui}, navigate to menu:Software[Manage > Channels].
+. Click btn:[Create Channel] and set these parameters for the entitlement certificate.
+Ensure you use the correct {rhela} version:
+* In the [guimenu]``Channel Name`` field, type [systemitem]``RHEL 7 x86_64``.
+* In the [guimenu]``Channel Label`` field, type [systemitem]``rhel7-x86_64-extras``.
+* In the [guimenu]``Parent Channel`` field, select [systemitem]``rhel7-x86_64-server``.
+* In the [guimenu]``Architecture`` field, select [systemitem]``x86_64``.
+* In the [guimenu]``Repository Checksum Type`` field, select [systemitem]``sha1``.
+* In the [guimenu]``Channel Summary`` field, type [systemitem]``RHEL 7 x86_64 Extras``.
+* In the [guimenu]``Organization Sharing`` field, select [systemitem]``Public``.
+. Click btn:[Create Channel].
+. Navigate to the [guimenu]``Repositories`` tab, check the appropriate repository, and click btn:[Update repositories].
+. OPTIONAL: Navigate to the [guimenu]``Sync`` tab to set a recurring schedule for synchronization of this repository.
+. Click btn:[Sync Now] to begin synchronization immediately.
 
-=== Add Client Tools channels
+
+[NOTE]
+====
+{rhel} channels can be very large.
+Synchronization can sometimes take several hours.
+====
+
+
+== Register Clients
+
+When you have set up all the custom channels, you can add the client tools, and register clients.
+
+For this section, you will require an activation key.
+For more information about activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+
 
 ifeval::[{suma-content} == true]
-SUSE Manager subscriptions entitle everyone to the tools channels for {sleses} (also known as Red Hat Expanded Support or RES). Any Red Hat Enterprise Linux system should use these to create the proper bootstrap repository for either traditional or salt-minion connectivity.
 
-1. Add the corresponding required {slesesa} channels and allow it to synchronize from SUSE Customer Center.
+Your {susemanager} subscription entitles you to the tools channels for {sleses} (also known as {redhat} Expanded Support or RES).
+You must use the client tools channel to create the bootstrap repository.
+This procedure applies to both traditional and Salt minions.
 
-{slesesa} 6::
-* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI.
 
-{slesesa} 7::
-* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI.
+.Procedure: Adding Client Tools Channels
 
-You can use [command]``mgr-sync`` to do it from CLI.
-
-2. Add the new channels to the activation key you created previously.
+. On the {productname} Server, add the appropriate {slesesa} channels:
++
+* For {slesesa} 6:
++
+From the {webui}, add [systemitem]``RHEL6 Base x86_64`` and [systemitem]``SUSE Linux Enterprise Client Tools RES6 x86_64``.
++
+From the command prompt, add [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64``.
++
+* For {slesesa} 7:
++
+From the {webui}, add [systemitem]``RHEL7 Base x86_64`` and [systemitem]``SUSE Linux Enterprise Client Tools RES7 x86_64``.
++
+From the command prompt, add [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64``.
+.  Synchronize the {productname} Server with the {SCC}.
+You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt. to do it from CLI.
+. Add the new channel to your activation key.
 
 endif::[]
+
+
 ifeval::[{uyuni-content} == true]
 
 // spacewalk-common-channels can't be used because centosX-uyuni-client requires centos7 channel as well, which a RHEL user would not need.
 
-1. On your {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+.Procedure: Adding Client Tools Channels
 
-Click **Create Repository**. The following screen opens, where you can enter the required information to create the repository.
+. On the {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+. Click btn:[Create Repository] and set these parameters for the entitlement certificate:
+* In the [guimenu]``Repository Label`` field, type [systemitem]``centos7-uyuni-client``.
+* In the [guimenu]``Repository URL`` field, type the URL of the repository to mirror.
+For example, [systemitem]``https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/``.
+* In the [guimenu]``Has Signed Metadata?`` field, uncheck all Red Hat Enterprise Repositories.
+* Leave all other fields as the default values.
+. Click btn:[Create Repository]
+. Navigate to menu:Software[Manage > Channels].
+. Click btn:[Create Channel] and set these parameters:
+Ensure you use the correct {rhela} version:
+* In the [guimenu]``Channel Name`` field, type [systemitem]``Uyuni Client Tools for CentOS 7 (x86_64)``.
+* In the [guimenu]``Channel Label`` field, type [systemitem]``centos7-uyuni-client-x86_64``.
+* In the [guimenu]``Parent Channel`` field, select [systemitem]``rhel7-x86_64-server``.
+* In the [guimenu]``Architecture`` field, select [systemitem]``x86_64``.
+* In the [guimenu]``Repository Checksum Type`` field, select [systemitem]``sha1``.
+* In the [guimenu]``Channel Summary`` field, type [systemitem]``Uyuni Client Tools for CentOS 7 (x86_64)``.
+* In the [guimenu]``Organization Sharing`` field, select [systemitem]``Public``.
+. Click btn:[Create Channel].
+. Navigate to the [guimenu]``Repositories`` tab, check the [systemitem]``centos7-uyuni-client`` repository, and click btn:[Update repositories].
+. OPTIONAL: Navigate to the [guimenu]``Sync`` tab to set a recurring schedule for synchronization of this repository.
+. Click btn:[Sync Now] to begin synchronization immediately.
+. Add the new channel to your activation key.
 
-Fill in the fields with values, following the example below:
-
-* **Repository Label:** centos7-uyuni-client
-* **Repository URL:** https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
-* **Has Signed Metadata?:** Uncheck
-
-Leave other filed with the default values.
-
-2. Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version and architecture):
-
-* **Channel Name:** Uyuni Client Tools for CentOS 7 (x86_64)
-* **Channel Label:** centos7-uyuni-client-x86_64
-* **Parent Channel:** rhel7-x86_64-server
-* **Architecture:** x86_64
-* **Repository Checksum Type:** sha1
-* **Channel Summary:** Uyuni Client Tools for CentOS 7 (x86_64)
-* **Organization Sharing:** Public
-
-After you have filled in the values, click again btn:[Create Channel].
-
-Click the [guimenu]``Repositories`` tab, and mark the checkbox for ``centos7-uyuni-client``, and then click btn:[Update repositories].
-
-Click the [guimenu]``Sync``tab, and set your preferred recurring schedule for synchronization for this repository. Select btn:[Sync Now] to launch the synchronization immediately.
-
-3. Add the new channel to the activation key you created previously
 endif::[]
 
-=== Bootstrap Repository Creation
 
-Create a bootstrap repository for your Red Hat Enterprise Linux clients with
+
+== Register Clients
+
+To register you {redhat} clients, you will need a bootstrap repository.
+Create the bootstrap repository at the command prompt, with this command:
 
 ----
 mgr-create-bootstrap-repo --with-custom-channels
 ----
 
-Ensure that it completes without error.
-
-== Register {rhela} Clients
-
-When you are ready to register your {rhel} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
+For more information on registering your clients, see xref:client-configuration:registration-overview.adoc[].

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -3,21 +3,22 @@
 
 This section contains information about registering traditional and Salt clients running {rhel} operating systems.
 
-[WARNING]
+[IMPORTANT]
 ====
-{rhel} Clients are completely based on {redhat} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesa})
-You are responsible for arranging access to {redhat} base media repositories and {rhela} installation media, as well as connecting {productname} Server to {redhat} Content Delivery Network
-You must obtain support from either {redhat} all your {rhela} systems.
+{rhel} clients are based on {redhat} and are unrelated to {sleses}, RES, {redhat}, or {slesa}.
+You are responsible for arranging access to {redhat} base media repositories and {rhela} installation media, as well as connecting {productname} Server to the {redhat} content delivery network.
+You must obtain support from {redhat} for all your {rhela} systems.
 If you do not do this, you might be violating your terms with {redhat}.
 ====
 
-== Server requirements
 
-Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
-Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
+== Server Requirements
 
-To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+Before you begin, check that your {productname} Server meets the requirements at xref:installation:hardware-requirements.adoc[].
+
+Taskomatic uses one CPU core, and requires at least 3072{nbsp}MB of RAM.
+To ensure that taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, and add this line:
 
 ----
 taskomatic.java.maxmemory=3072
@@ -28,78 +29,88 @@ Restart Taskomatic:
 systemctl restart taskomatic
 ----
 
-== Import {redhat} Entitlement and CA Certificate
+== Import Entitlements and CA Certificate
 
-During the next few paragraphs, you will learn how to import the {redhat} CA and entitlement certificate.
+{redhat} clients require a {redhat} certificate authority (CA) and entitlement certificate.
 
-[WARNING]
-====
-Entitlement certificates have embedded expiration dates tied to the length of the support subscription. You must repeat this process with updated entitlement certificates as needed to avoid disruption in channel mirroring.
-====
+Entitlement certificates are embedded with expiration dates, which match the length of the support subscription.
+To avoid disruption, you will need to repeat this process at the end of every support subscription period.
 
-=== Entitlement Certificate
+{redhat} supply a subscription manager tool to manage subscription assignments.
+It runs locally to track installed products and subscriptions.
+Clients must be registered with the subscription manager to obtain certificates.
 
-{redhat} Subscription Manager is a local service which tracks installed products and subscriptions on a local system to help manage subscription assignments. To obtain your certificates, you must register your system using this subscription manager tool supplied by {redhat}.
+.Procedure: Registering Clients to Subscription Manager
 
-1. Register with the subscription manager tool from your {redhat} client. It will prompt you for your user name and password for authentication on the {redhat} Portal:
-
+. On the client system, at the command prompt, register with the subscription manager tool:
++
 ----
 subscription-manager register
 ----
-
-2. Navigate to the location of your entitlement certificate and key, and copy these files to where your Web browser connected to {productname} Server can open them:
-
++
+Enter your {redhat} Portal username and password when prompted.
+. Copy your entitlement certificate and key from the client system, to a location that the {productname} Server can access:
++
 ----
-cd /etc/pki/entitlement/
+cp /etc/pki/entitlement/ /<example>/entitlement/
+----
++
+[NOTE]
+====
+Your entitlement certificate and key will both have a file extension of [path]``.pem``.
+The key will also have [path]``key`` in the filename.
+====
++
+. Copy the {redhat} CA Certificate file from the client system, to the same web location as the entitlement certificate and key:
++
+----
+cp /etc/rhsm/ca/redhat-uep.pem /example/entitlement
 ----
 
-You will see two files with the data file format extension .pem (Program Editor macro). One is the certificate, and the other is the key and it has the word “key” in the file name.
 
-=== {redhat} CA Certificate
+To manage repositories on your {redhat} client, you need to import the CA and entitlement certificates to the {productname} Server.
+This requires three entries: one each for the entitlement certificate, the entitlement key, and the {redhat} certificate.
 
-The next step is to get the {redhat} CA Certificate file. It is located on this same {redhat} system in the file [path]``/etc/rhsm/ca/redhat-uep.pem``. Place this file in the same location where, in the previous section, you put the entitlement certificate.
 
-=== Obtain Repository URL list
 
-Use the subscription manager tool to obtain the URL’s of the repositories you want to mirror:
+.Procedure: Importing Certificates to the Server
+
+. On the {productname} Server {webui}, navigate to menu:Systems[Autoinstallation > GPG and SSL Keys].
++
+// Maybe we  should add a screenshot, as we have at the current guide: https://documentation.suse.com/sbp/all/html/SBP-sumaforrhel/index.html#sec-import
+// Not necessary, it's pretty simple to navigate to a page. LKB
+
+. Click btn:[Create Stored Key/Cert] and set these parameters for the entitlement certificate:
+* In the [guimenu]``Description`` field, type [systemitem]``Entitlement-Cert-date``.
+* In the [guimenu]``Type`` field, select [systemitem]``SSL``
+* In the [guimenu]``Select file to upload`` field, browse to the location where you saved the entitlement certificate, and select the [path]``.pem`` certificate file.
+. Click btn:[Create Key].
+. Click btn:[Create Stored Key/Cert] and set these parameters for the entitlement key:
+* In the [guimenu]``Description`` field, type [systemitem]``Entitlement-key-date``.
+* In the [guimenu]``Type`` field, select [systemitem]``SSL``
+* In the [guimenu]``Select file to upload`` field, browse to the location where you saved the entitlement key, and select the [path]``.pem`` key file.
+. Click btn:[Create Key].
+. Click btn:[Create Stored Key/Cert] and set these parameters for the {redhat} certificate:
+* In the [guimenu]``Description`` field, type [systemitem]``redhat-uep``.
+* In the [guimenu]``Type`` field, select [systemitem]``SSL``
+* In the [guimenu]``Select file to upload`` field, browse to the location where you saved the {redhat} certificate, and select the certificate file.
+. Click btn:[Create Key].
+
+// put the screenshot here as a result. LKB
+
+
+// Lana, you're up to here! 2019-09-27
+
+== Repository Management
+
+
+
+You can use the subscription manager tool to get the URLs of the repositories you want to mirror:
 
 ----
 subscription-manager repos
 ----
 
-=== Import
-
-Now you are ready to import the {redhat} CA Certificate and Entitlement Certificate into {productname} Server for software repository mirroring. You must create three entries here: one each for the entitlement certificate, the entitlement key, and the {redhat} certificate.
-
-* In the {productname} {webui}, navigate to menu:Systems[Autoinstallation > GPG and SSL Keys].
-
-// Maybe we  should add a screenshot, as we have at the current guide: https://documentation.suse.com/sbp/all/html/SBP-sumaforrhel/index.html#sec-import
-
-* Click **Create Stored Key/Cert** on the right. Another screen opens where you can fill in the required information.
-
-// Another screenshot.
-
-Enter the following values, and ensure you enter the date:
-
-* **Description:** Entitlement-Cert-date
-* **Type:** Ensure you select SSL
-* **Select file to upload:** Browse to where you saved the Entitlement Certificate .pem file and select it.
-
-Click the btn:[Create Key] at the bottom.
-
-Repeat the above steps for the Entitlement Key and change the values to match the following:
-
-* **Description:** Entitlement-key-date
-* **Type:** SSL
-* **Select file to upload:** Browse to the location where you saved the Entitlement key .pem file and select it.
-
-Repeat the above steps for the {redhat} CA Certificate (redhat-uep) and change the values to match the following:
-
-* **Description:** redhat-uep
-* **Type:** SSL
-* **Select file to upload:** Browse to the location where you saved the {redhat} CA Certificate and select it.
-
-You now have imported the Entitlement certificate, the Entitlement key and the {redhat} CA into {productname} Server for use. Your outcome should look like the screen below:
 
 == Create Software Repositories
 

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -342,6 +342,7 @@ You need to modify the activation keys you used for RHEL systems to include the 
 ifeval::[{suma-content} == true]
 By default, {rhel} does not trust the GPG key for {productname} {slesesa} client tools.
 endif::[]
+
 ifeval::[{uyuni-content} == true]
 By default, {rhel} does not trust the GPG key for {productname} {centos} client tools.
 endif::[]
@@ -357,6 +358,7 @@ ifeval::[{suma-content} == true]
 sle12-gpg-pubkey-39db7c82.key
 ----
 endif::[]
+
 ifeval::[{uyuni-content} == true]
 ----
 uyuni-gpg-pubkey-0d20833e.key
@@ -368,8 +370,6 @@ You do not need to delete any previously stored keys.
 If you are boostrapping clients from the {productname} {webui}, you will need to use a salt state to trust the key.
 Create the salt state and assign it to the organization.
 You can then use an activation key and configuration channels to deploy the key to the clients.
-
-endif::[]
 
 
 

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -82,17 +82,17 @@ This requires three entries: one each for the entitlement certificate, the entit
 
 . Click btn:[Create Stored Key/Cert] and set these parameters for the entitlement certificate:
 * In the [guimenu]``Description`` field, type [systemitem]``Entitlement-Cert-date``.
-* In the [guimenu]``Type`` field, select [systemitem]``SSL``
+* In the [guimenu]``Type`` field, select [systemitem]``SSL``.
 * In the [guimenu]``Select file to upload`` field, browse to the location where you saved the entitlement certificate, and select the [path]``.pem`` certificate file.
 . Click btn:[Create Key].
 . Click btn:[Create Stored Key/Cert] and set these parameters for the entitlement key:
 * In the [guimenu]``Description`` field, type [systemitem]``Entitlement-key-date``.
-* In the [guimenu]``Type`` field, select [systemitem]``SSL``
+* In the [guimenu]``Type`` field, select [systemitem]``SSL``.
 * In the [guimenu]``Select file to upload`` field, browse to the location where you saved the entitlement key, and select the [path]``.pem`` key file.
 . Click btn:[Create Key].
 . Click btn:[Create Stored Key/Cert] and set these parameters for the {redhat} certificate:
 * In the [guimenu]``Description`` field, type [systemitem]``redhat-uep``.
-* In the [guimenu]``Type`` field, select [systemitem]``SSL``
+* In the [guimenu]``Type`` field, select [systemitem]``SSL``.
 * In the [guimenu]``Select file to upload`` field, browse to the location where you saved the {redhat} certificate, and select the certificate file.
 . Click btn:[Create Key].
 
@@ -129,7 +129,7 @@ For example, [systemitem]``https://cdn.redhat.com/content/dist/rhel/server/7/7Se
 * In the [guimenu]``SSL Client Certificate`` field, select [systemitem]``Entitlement-Cert-date``.
 * In the [guimenu]``SSL Client Key`` field, select [systemitem]``Entitlement-Key-date``.
 * Leave all other fields as the default values.
-. Click btn:[Create Repository]
+. Click btn:[Create Repository].
 . Repeat for every repository you want to define.
 
 
@@ -238,7 +238,7 @@ ifeval::[{uyuni-content} == true]
 For example, [systemitem]``https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/``.
 * In the [guimenu]``Has Signed Metadata?`` field, uncheck all Red Hat Enterprise Repositories.
 * Leave all other fields as the default values.
-. Click btn:[Create Repository]
+. Click btn:[Create Repository].
 . Navigate to menu:Software[Manage > Channels].
 . Click btn:[Create Channel] and set these parameters.
 Ensure you use the correct {rhela} version:

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -204,7 +204,7 @@ For more information about activation keys, see xref:client-configuration:client
 
 ifeval::[{suma-content} == true]
 
-Your {susemanager} subscription entitles you to the tools channels for {sleses} (also known as {redhat} Expanded Support or RES).
+Your {susemgr} subscription entitles you to the tools channels for {sleses} (also known as {redhat} Expanded Support or RES).
 You must use the client tools channel to create the bootstrap repository.
 This procedure applies to both traditional and Salt minions.
 
@@ -268,12 +268,14 @@ You can choose to disable the {rhel} subscription-manager yum plugins.
 
 The yum plugins are disabled with a configuration Salt state.
 
-.Procedure: Creating a Salt State to Deploy Configuration Files
-
 [NOTE]
 ====
 This procedure is optional.
 ====
+
+
+
+.Procedure: Creating a Salt State to Deploy Configuration Files
 
 . On the {productname} Server {webui}, navigate to menu:Configuration[Channels].
 . Click btn:[Create State Channel]
@@ -337,6 +339,8 @@ You need to modify the activation keys you used for RHEL systems to include the 
 . Check [systemitem]``Select rhel-systems```
 . Click btn:[Join Selected Groups]
 
+
+
 == Trust GPG Keys on Clients
 
 ifeval::[{suma-content} == true]
@@ -373,12 +377,9 @@ You can then use an activation key and configuration channels to deploy the key 
 
 
 
-.Procedure: Adding Client Tools Channels
-
-
 == Register Clients
 
-To register you {redhat} clients, you will need a bootstrap repository.
+To register your {redhat} clients, you will need a bootstrap repository.
 Create the bootstrap repository at the command prompt, with this command:
 
 ----

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -219,7 +219,7 @@ From the {webui}, add [systemitem]``RHEL7 Base x86_64`` and [systemitem]``SUSE L
 +
 From the command prompt, add [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64``.
 .  Synchronize the {productname} Server with the {SCC}.
-You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt. to do it from CLI.
+You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt.
 . Add the new channel to your activation key.
 
 endif::[]

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -1,249 +1,272 @@
 [[clients-rh]]
 = Registering {rhel} Clients
 
-
 This section contains information about registering traditional and Salt clients running {rhel} operating systems.
 
+[WARNING]
+====
+{rhel} Clients are completely based on {redhat} and unrelated to {sleses} Clients (also known as RES or {redhat} {slesa})
+You are responsible for arranging access to {redhat} base media repositories and {rhela} installation media, as well as connecting {productname} Server to {redhat} Content Delivery Network
+You must obtain support from either {redhat} all your {rhela} systems.
+If you do not do this, you might be violating your terms with {redhat}.
+====
 
+== Server requirements
 
-== Set up a {rhel} Client
-
-Ensure that your client meets these requirements before you start:
-
-* 8{nbsp}GB RAM or more
-* Two or more physical or virtual CPU cores
-* Access to {rhel} installation and subscription media
-* An LVM or an NFS mount is recommended
-
-You will need to ensure you provision enough disk space.
-The [path]``/var/spacewalk`` directory contains all mirrored RPMs,  and can take a significant amount of disk space.
-For example, the {rhel}{nbsp}6 x86_64 channels require over 90{nbsp}GB.
+Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 
 Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
-To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, and add this line:
+
+To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
 
 ----
 taskomatic.java.maxmemory=3072
 ----
 
+Restart Taskomatic:
+----
+systemctl restart taskomatic
+----
+
+== Import {redhat} Entitlement and CA Certificate
+
+During the next few paragraphs, you will learn how to import the {redhat} CA and entitlement certificate.
+
 [WARNING]
 ====
-You are responsible for arranging access to Red Hat base media repositories and RHEL installation media.
-You must obtain support from either Red Hat or {suse} for all your RHEL systems.
-If you do not do this, you might be violating your terms with Red Hat.
+Entitlement certificates have embedded expiration dates tied to the length of the support subscription. You must repeat this process with updated entitlement certificates as needed to avoid disruption in channel mirroring.
 ====
 
+==== Entitlement Certificate
 
+{redhat} Subscription Manager is a local service which tracks installed products and subscriptions on a local system to help manage subscription assignments. To obtain your certificates, you must register your system using this subscription manager tool supplied by {redhat}.
 
-== {rhel} Channel Management
+1. Register with the subscription manager tool from your {redhat} client. It will prompt you for your user name and password for authentication on the {redhat} Portal:
 
-The base {rhel} software channel does not contain any packages.
-This is because {suse} does not provide {rhel} base media.
-You will need to obtain base media from Red Hat, which you can then add as a child channel to the {rhel} parent channel.
-
-The {rhel} and tools channels are provided by {scc}.
-You can synchronize your client with the [command]``mgr-sync`` command to get them.
-
-Because the {rhel} channels are particularly large, it can take up to 24 hours for an initial channel synchronization to complete.
-When you have completed the initial synchronization, we recommended you clone the channel before working with it.
-This provides you with a backup of the original synchronization data.
-
-The following procedure guides you through setup of the {rhel} media as a {productname} channel.
-All packages on the media will be mirrored into a child channel located under the distribution name and architecture.
-
-.Procedure: Setting up a {rhel} Channel
-. In the {productname} {webui}, navigate to menu:Channels[Manage Software Channels], and click btn:[Create Channel].
-. Fill in the channel details, and add the channel as a child to the corresponding {rhel} distribution channel for your architecture.
-The base parent channel will not contain any packages.
-. Modify the associated activation key to include your new child channel.
-. At the command prompt, as root, copy your installation disk image to the [path]``/tmp`` directory.
-. Create a directory to contain the media content:
-+
 ----
-mkdir -p /srv/www/htdocs/pub/rhel
-----
-. Mount the ISO:
-+
-----
-mount -o loop /tmp/name_of_iso /srv/www/htdocs/pub/rhel
-----
-. Synchronize the packages with [command]``spacewalk-repo-sync``:
-+
-For {rhel} 7:
-+
-----
-spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/
-Repo URL: https://127.0.0.1/pub/rhel/
-Packages in repo:              [...]
-Packages already synced:       [...]
-Packages to sync:              [...]
-[...]
-----
-+
-For {rhel} 6:
-+
-----
-spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/Server/
-Repo URL: https://127.0.0.1/pub/rhel/Server/
-Packages in repo:              [...]
-Packages already synced:       [...]
-Packages to sync:              [...]
-[...]
+subscription-manager register
 ----
 
-Sometimes, the [command]``spacewalk-repo-sync`` will stop running during a synchronization, which will give this error:
-----
-[Errno 256] No more mirrors to try.
-----
+2. Navigate to the location of your entitlement certificate and key, and copy these files to where your Web browser connected to {productname} Server can open them:
 
-If this occurs, you can run [command]``spacewalk-repo-sync`` in debugging mode to determine the error.
-
-Start debugging mode:
 ----
-export URLGRABBER_DEBUG=DEBUG
+cd /etc/pki/entitlement/
 ----
 
-Check the output:
+You will see two files with the data file format extension .pem (Program Editor macro). One is the certificate, and the other is the key and it has the word “key” in the file name.
+
+==== {redhat} CA Certificate
+
+The next step is to get the {redhat} CA Certificate file. It is located on this same {redhat} system in the file [path]``/etc/rhsm/ca/redhat-uep.pem``. Place this file in the same location where, in the previous section, you put the entitlement certificate.
+
+==== Obtain Repository URL list
+
+Use the subscription manager tool to obtain the URL’s of the repositories you want to mirror:
+
 ----
-/usr/bin/spacewalk-repo-sync --channel _<channel-label>_ --type yum
+subscription-manager repos
 ----
 
-Disable debug mode:
-----
-unset URLGRABBER_DEBUG``
-----
+==== Import
 
+Now you are ready to import the {redhat} CA Certificate and Entitlement Certificate into {productname} Server for software repository mirroring. You must create three entries here: one each for the entitlement certificate, the entitlement key, and the {redhat} certificate.
 
+* In the {productname} {webui}, navigate to menu:Systems[Autoinstallation > GPG and SSL Keys].
 
-== Register {rhel} Clients
+// Maybe we  should add a screenshot, as we have at the current guide: https://documentation.suse.com/sbp/all/html/SBP-sumaforrhel/index.html#sec-import
 
+* Click **Create Stored Key/Cert** on the right. Another screen opens where you can fill in the required information.
 
-Before you register {rhel} clients to your {productname} Server, check that you have the corresponding {rhel} product enabled, and the required channels are fully synchronized.
+// Another screenshot.
 
-You will also need an activation key associated with the {rhel} channel.
-For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+Enter the following values, and ensure you enter the date:
 
-[IMPORTANT]
+**Description:** Entitlement-Cert-date
+**Type:** Ensure you select SSL
+**Select file to upload:** Browse to where you saved the Entitlement Certificate .pem file and select it.
+
+Click the btn:[Create Key] at the bottom.
+
+Repeat the above steps for the Entitlement Key and change the values to match the following:
+
+**Description:** Entitlement-key-date
+**Type:** SSL
+**Select file to upload:** Browse to the location where you saved the Entitlement key .pem file and select it.
+
+Repeat the above steps for the {redhat} CA Certificate (redhat-uep) and change the values to match the following:
+
+**Description:** redhat-uep
+**Type:** SSL
+**Select file to upload:** Browse to the location where you saved the {redhat} CA Certificate and select it.
+
+You now have imported the Entitlement certificate, the Entitlement key and the {redhat} CA into {productname} Server for use. Your outcome should look like the screen below:
+
+== Create Software Repositories
+
+[WARNING]
 ====
-Missing packages will cause your registration to fail.
-For {rhel} clients, packages are contained on the {rhel} installation media.
-Ensure you have loop-mounted the installation media, and added it as a child channel to the base {rhel} channel.
+Use the output of repository URL’s obtained earlier from the subscription manager tool to create other repositories to which you are entitled. Mirror only the content which you need to manage your systems.
 ====
 
+To mirror the software from the {redhat} CDN, you need to create custom channels and repositories in {productname} Server that are linked to the CDN with their respective URL. This will only work if you have entitlements to these products in your {redhat} Portal. To create these software repositories you need to perform the following actions.
 
-{rhel} 7::
-* Product: {rhel} 7
-* Mandatory channels: [systemitem]``rhel-x86_64-server-7`` , [systemitem]``res7-suse-manager-tools-x86_64`` , [systemitem]``res7-x86_64``
+On your {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+
+// Maybe a screenshot could help, as the original guide.
+
+Click **Create Repository**. The following screen opens, where you can enter the required information to create the repository.
+
+// Maybe a screenshot could help, as the original guide.
+
+Fill in the fields with values, following the example below:
+
+**Repository Label:** rhel-7-server-rpms
+**Repository URL:** https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+**Has Signed Metadata?:** Uncheck (Uncheck for all Red Hat Enterprise Repositories)
+**SSL CA Certificate:** redhat-uep
+**SSL Client Certificate:** Entitlement-Cert-date
+**SSL Client Key:** Entitlement-Key-date
+
+Leave other filed with the default values.
+
+These steps need to be repeated for the Products / Repository URLs you define for your environment.
+
+== Create Software Channel Delivery
+
+Next step is to create corresponding channels to which you assign these repositories.
+
+On your {productname} Server {webui}, navigate to menu:Software[Manage > Channels].
+
+=== Parent Channels Example
+
+Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
+
+**Channel Name:** RHEL 7 x86_64
+**Channel Label:** rhel7-x86_64-server
+**Parent Channel:** None
+**Architecture:** x86_64
+**Repository Checksum Type:** sha1
+**Channel Summary:** RHEL 7 x86_64
+**Organization Sharing:** Public
 
 
-{rhel} 6::
-* Product: {rhel} 6
-* Mandatory channels: [systemitem]``rhel-x86_64-server-6`` , [systemitem]``res6-suse-manager-tools-x86_64`` , [systemitem]``res6-x86_64``
+After you have filled in the values, click again **Create Channel**.
+
+Click the [guimenu]``Repositories`` tab, and mark the checkbox next to the appropriate repository, and then click btn:[Update repositories].
+
+// Add a screenshot
+
+Click the [guimenu]``Sync`` tab, and set your preferred recurring schedule for synchronization for this repository. Select btn:[Sync Now] to launch the synchronization immediately.
+
+[WARNING]
+====
+{rhel} OS channels can grow to be very large. Thus it can take several hours to complete mirroring.
+====
+
+// add a screenshot
+
+=== Child Channels example
+
+Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
+
+**Channel Name:** RHEL 7 x86_64
+**Channel Label:** rhel7-x86_64-extras
+**Parent Channel:** rhel7-x86_64-server (from drop-down box)
+**Architecture:** x86_64
+**Repository Checksum Type:** sha1
+**Channel Summary:** RHEL 7 x86_64 Extras
+**Organization Sharing:** Public
 
 
-There are two ways to check if a channel has finished synchronizing:
+After you have filled in the values, click again **Create Channel**.
 
-* In the {productname}{webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
-This dialog displays a completion bar for each product when they are being synchronized.
-* You can also check the synchronization log file at the command prompt.
-Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
-If you use this method, remember that base channels can contain multiple child channels.
-Each of the child channels will generate its own log during the synchronization progress.
-You will need to check all the base and child channel log files to be sure that the synchronization is complete.
+Click the [guimenu]``Repositories`` tab, and mark the checkbox next to the appropriate repository, and then click btn:[Update repositories].
+
+// Add a screenshot
+
+Click the [guimenu]``Syn`` tab, and set your preferred recurring schedule for synchronization for this repository. You can also select btn:[Sync Now] to launch the synchronization immediately.
+
+[WARNING]
+====
+Some of the {rhel} channels can grow to be very large. Thus it can take several hours to complete mirroring.
+====
+
+// add a screenshot
+
+== Activation key
+
+Now you can proceed to create the activation key in the {productname} Server {webui}, and assign appropriate channels to it.
+
+== Registration
+
+=== Add Client Tools channels
+
+ifeval::[{suma-content} == true]
+SUSE Manager subscriptions entitle everyone to the tools channels for {sleses} (also known as Red Hat Expanded Support or RES). Any Red Hat Enterprise Linux system should use these to create the proper bootstrap repository for either traditional or salt-minion connectivity.
+
+1. Add the corresponding required {slesesa} channels and allow it to synchronize from SUSE Customer Center.
+
+{slesesa} 6::
+* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI.
+
+{slesesa} 7::
+* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI.
+
+You can use [command]``mgr-sync`` to do it from CLI.
+
+// I am not sure we need this, as we instruct users to sync the repositories, including "os" (pool) and updates. I asked clarification from Donald.
+//2. Follow the instructions to synchronize your base media as a child repository for your distribution based on Red Hat Enterprise Linux, as explained in the SUSE Manager Wiki:
+//
+//https://wiki.microfocus.com/index.php/SUSE_Manager/Sync_RHEL_media
+
+3. Add the new channels to the activation key you created previously.
+
+endif::[]
+ifeval::[{uyuni-content} == true]
+
+// spacewalk-common-channels can't be used because centosX-uyuni-client requires centos7 channel as well, which a RHEL user would not need.
+
+1. On your {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+
+Click **Create Repository**. The following screen opens, where you can enter the required information to create the repository.
+
+Fill in the fields with values, following the example below:
+
+**Repository Label:** centos7-uyuni-client
+**Repository URL:** https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+**Has Signed Metadata?:** Uncheck
+
+Leave other filed with the default values.
+
+2. Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version and architecture):
+
+**Channel Name:** Uyuni Client Tools for CentOS 7 (x86_64)
+**Channel Label:** centos7-uyuni-client-x86_64
+**Parent Channel:** rhel7-x86_64-server
+**Architecture:** x86_64
+**Repository Checksum Type:** sha1
+**Channel Summary:** Uyuni Client Tools for CentOS 7 (x86_64)
+**Organization Sharing:** Public
+
+After you have filled in the values, click again btn:[Create Channel].
+
+Click the [guimenu]``Repositories`` tab, and mark the checkbox for ``centos7-uyuni-client``, and then click btn:[Update repositories].
+
+Click the [guimenu]``Sync``tab, and set your preferred recurring schedule for synchronization for this repository. Select btn:[Sync Now] to launch the synchronization immediately.
+
+3. Add the new channel to the activation key you created previously
+endif::[]
+
+=== Bootstrap Repository Creation
+
+Create a bootstrap repository for your Red Hat Enterprise Linux clients with
+
+----
+mgr-create-bootstrap-repo --with-custom-channels
+----
+
+Ensure that it completes without error.
+
+== Register {rhela} Clients
 
 When you are ready to register your {rhel} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
-
-
-
-
-
-////
-This is all duplicated content. LKB 2018-08-31
-
-.Procedure: Registering a bootstrap repository:
-
- . At the command prompt on the {productname} Server, as root, create a bootstrap repository for {rhel}:
-+
-----
-mgr-create-bootstrap-repo RHEL_activation_channel_key
-----
-+
-If you use a dedicated channel per RHEL version, specify it with the [literal]``--with-custom-channel`` option.
-
-. Rename [command]``bootstrap.sh`` to [command]``resversion-boostrap.sh``:
-+
-
-----
-cp bootstrap.sh res7-bootstrap.sh
-----
-
-
-== Register a Salt Client via Bootstrap
-
-
-The following procedure will guide you through registering a Salt client using the bootstrap script.
-
-.Procedure: Registration Using the Bootstrap Script
-. For your new client download the bootstrap script from the {productname} server:
-+
-
-----
-wget --no-check-certificate https://`server`/pub/bootstrap/res7-bootstrap.sh
-----
-. Add the appropriate res-gpg-pubkey-#####-#####.key to the `ORG_GPG_KEY` key parameter, comma delimited in your [command]``res7-bootstrap.sh`` script. These are located on your {productname} server at:
-+
-
-----
-http://`server`/pub/
-----
-. Make the [command]``res7-bootstrap.sh`` script executable and run it. This will install necessary Salt packages from the bootstrap repository and start the Salt client service:
-+
-
-----
-chmod +x res7-bootstrap.sh
-./res7-boostrap.sh
-----
-
-. From the {productname} {webui} select menu:Salt[Keys] and accept the new client's key.
-
-////
-
-
-////
-I'm fairly certain this isn't supported, which is why we took it out of the SLE instructions. LKB 2018-08-12
-
-== Manual Salt Client Registration
-
-
-The following procedure will guide you through the registration of a Salt client manually.
-
-
-. Add the bootstrap repository:
-+
-
-----
-yum-config-manager --add-repo https://`server`/pub/repositories/res/7/bootstrap
-----
-. Install the [package]#salt-minion# package:
-+
-
-----
-yum install salt-minion
-----
-. Edit the Salt client configuration file to point to the {productname} server:
-+
-
-----
-mkdir /etc/salt/minion.d
-echo "master:`server_fqdn`" > /etc/salt/minion.d/susemanager.conf
-----
-. Start the client service:
-+
-
-----
-systemctl start salt-minion
-----
-
-. From the {productname} {webui} select the menu:Salt[Keys] and accept the new client's key.
-
-////

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -270,7 +270,7 @@ endif::[]
 . Click btn:[Create Config Channel]
 . Click btn:[Create Configuration File]
 * In the [guimenu]``Filename/Path`` field type [systemitem]``/etc/yum/pluginconf.d/subscription-manager.conf``.
-* In the [guimenu]``File Contents``` field type:
+* In the [guimenu]``File Contents`` field type:
 ----
 [main]
 enabled=0

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -37,7 +37,7 @@ During the next few paragraphs, you will learn how to import the {redhat} CA and
 Entitlement certificates have embedded expiration dates tied to the length of the support subscription. You must repeat this process with updated entitlement certificates as needed to avoid disruption in channel mirroring.
 ====
 
-==== Entitlement Certificate
+=== Entitlement Certificate
 
 {redhat} Subscription Manager is a local service which tracks installed products and subscriptions on a local system to help manage subscription assignments. To obtain your certificates, you must register your system using this subscription manager tool supplied by {redhat}.
 
@@ -55,11 +55,11 @@ cd /etc/pki/entitlement/
 
 You will see two files with the data file format extension .pem (Program Editor macro). One is the certificate, and the other is the key and it has the word “key” in the file name.
 
-==== {redhat} CA Certificate
+=== {redhat} CA Certificate
 
 The next step is to get the {redhat} CA Certificate file. It is located on this same {redhat} system in the file [path]``/etc/rhsm/ca/redhat-uep.pem``. Place this file in the same location where, in the previous section, you put the entitlement certificate.
 
-==== Obtain Repository URL list
+=== Obtain Repository URL list
 
 Use the subscription manager tool to obtain the URL’s of the repositories you want to mirror:
 
@@ -67,7 +67,7 @@ Use the subscription manager tool to obtain the URL’s of the repositories you 
 subscription-manager repos
 ----
 
-==== Import
+=== Import
 
 Now you are ready to import the {redhat} CA Certificate and Entitlement Certificate into {productname} Server for software repository mirroring. You must create three entries here: one each for the entitlement certificate, the entitlement key, and the {redhat} certificate.
 
@@ -81,23 +81,23 @@ Now you are ready to import the {redhat} CA Certificate and Entitlement Certific
 
 Enter the following values, and ensure you enter the date:
 
-**Description:** Entitlement-Cert-date
-**Type:** Ensure you select SSL
-**Select file to upload:** Browse to where you saved the Entitlement Certificate .pem file and select it.
+* **Description:** Entitlement-Cert-date
+* **Type:** Ensure you select SSL
+* **Select file to upload:** Browse to where you saved the Entitlement Certificate .pem file and select it.
 
 Click the btn:[Create Key] at the bottom.
 
 Repeat the above steps for the Entitlement Key and change the values to match the following:
 
-**Description:** Entitlement-key-date
-**Type:** SSL
-**Select file to upload:** Browse to the location where you saved the Entitlement key .pem file and select it.
+* **Description:** Entitlement-key-date
+* **Type:** SSL
+* **Select file to upload:** Browse to the location where you saved the Entitlement key .pem file and select it.
 
 Repeat the above steps for the {redhat} CA Certificate (redhat-uep) and change the values to match the following:
 
-**Description:** redhat-uep
-**Type:** SSL
-**Select file to upload:** Browse to the location where you saved the {redhat} CA Certificate and select it.
+* **Description:** redhat-uep
+* **Type:** SSL
+* **Select file to upload:** Browse to the location where you saved the {redhat} CA Certificate and select it.
 
 You now have imported the Entitlement certificate, the Entitlement key and the {redhat} CA into {productname} Server for use. Your outcome should look like the screen below:
 
@@ -120,12 +120,12 @@ Click **Create Repository**. The following screen opens, where you can enter the
 
 Fill in the fields with values, following the example below:
 
-**Repository Label:** rhel-7-server-rpms
-**Repository URL:** https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
-**Has Signed Metadata?:** Uncheck (Uncheck for all Red Hat Enterprise Repositories)
-**SSL CA Certificate:** redhat-uep
-**SSL Client Certificate:** Entitlement-Cert-date
-**SSL Client Key:** Entitlement-Key-date
+* **Repository Label:** rhel-7-server-rpms
+* **Repository URL:** https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+* **Has Signed Metadata?:** Uncheck (Uncheck for all Red Hat Enterprise Repositories)
+* **SSL CA Certificate:** redhat-uep
+* **SSL Client Certificate:** Entitlement-Cert-date
+* **SSL Client Key:** Entitlement-Key-date
 
 Leave other filed with the default values.
 
@@ -141,13 +141,13 @@ On your {productname} Server {webui}, navigate to menu:Software[Manage > Channel
 
 Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
 
-**Channel Name:** RHEL 7 x86_64
-**Channel Label:** rhel7-x86_64-server
-**Parent Channel:** None
-**Architecture:** x86_64
-**Repository Checksum Type:** sha1
-**Channel Summary:** RHEL 7 x86_64
-**Organization Sharing:** Public
+* **Channel Name:** RHEL 7 x86_64
+* **Channel Label:** rhel7-x86_64-server
+* **Parent Channel:** None
+* **Architecture:** x86_64
+* **Repository Checksum Type:** sha1
+* **Channel Summary:** RHEL 7 x86_64
+* **Organization Sharing:** Public
 
 
 After you have filled in the values, click again **Create Channel**.
@@ -169,13 +169,13 @@ Click the [guimenu]``Sync`` tab, and set your preferred recurring schedule for s
 
 Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version):
 
-**Channel Name:** RHEL 7 x86_64
-**Channel Label:** rhel7-x86_64-extras
-**Parent Channel:** rhel7-x86_64-server (from drop-down box)
-**Architecture:** x86_64
-**Repository Checksum Type:** sha1
-**Channel Summary:** RHEL 7 x86_64 Extras
-**Organization Sharing:** Public
+* **Channel Name:** RHEL 7 x86_64
+* **Channel Label:** rhel7-x86_64-extras
+* **Parent Channel:** rhel7-x86_64-server (from drop-down box)
+* **Architecture:** x86_64
+* **Repository Checksum Type:** sha1
+* **Channel Summary:** RHEL 7 x86_64 Extras
+* **Organization Sharing:** Public
 
 
 After you have filled in the values, click again **Create Channel**.
@@ -214,12 +214,7 @@ SUSE Manager subscriptions entitle everyone to the tools channels for {sleses} (
 
 You can use [command]``mgr-sync`` to do it from CLI.
 
-// I am not sure we need this, as we instruct users to sync the repositories, including "os" (pool) and updates. I asked clarification from Donald.
-//2. Follow the instructions to synchronize your base media as a child repository for your distribution based on Red Hat Enterprise Linux, as explained in the SUSE Manager Wiki:
-//
-//https://wiki.microfocus.com/index.php/SUSE_Manager/Sync_RHEL_media
-
-3. Add the new channels to the activation key you created previously.
+2. Add the new channels to the activation key you created previously.
 
 endif::[]
 ifeval::[{uyuni-content} == true]
@@ -232,21 +227,21 @@ Click **Create Repository**. The following screen opens, where you can enter the
 
 Fill in the fields with values, following the example below:
 
-**Repository Label:** centos7-uyuni-client
-**Repository URL:** https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
-**Has Signed Metadata?:** Uncheck
+* **Repository Label:** centos7-uyuni-client
+* **Repository URL:** https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+* **Has Signed Metadata?:** Uncheck
 
 Leave other filed with the default values.
 
 2. Click **Create Channel** and fill in the fields with at least the following values (change according to your {rhela} version and architecture):
 
-**Channel Name:** Uyuni Client Tools for CentOS 7 (x86_64)
-**Channel Label:** centos7-uyuni-client-x86_64
-**Parent Channel:** rhel7-x86_64-server
-**Architecture:** x86_64
-**Repository Checksum Type:** sha1
-**Channel Summary:** Uyuni Client Tools for CentOS 7 (x86_64)
-**Organization Sharing:** Public
+* **Channel Name:** Uyuni Client Tools for CentOS 7 (x86_64)
+* **Channel Label:** centos7-uyuni-client-x86_64
+* **Parent Channel:** rhel7-x86_64-server
+* **Architecture:** x86_64
+* **Repository Checksum Type:** sha1
+* **Channel Summary:** Uyuni Client Tools for CentOS 7 (x86_64)
+* **Organization Sharing:** Public
 
 After you have filled in the values, click again btn:[Create Channel].
 

--- a/modules/client-configuration/pages/clients-rh.adoc
+++ b/modules/client-configuration/pages/clients-rh.adoc
@@ -187,9 +187,10 @@ Synchronization can sometimes take several hours.
 ====
 
 
-== Register Clients
 
-When you have set up all the custom channels, you can add the client tools, and register clients.
+== Add Client Tools
+
+When you have set up all the custom channels, you can add the client tools.
 
 For this section, you will require an activation key.
 For more information about activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
@@ -239,7 +240,7 @@ For example, [systemitem]``https://download.opensuse.org/repositories/systemsman
 * Leave all other fields as the default values.
 . Click btn:[Create Repository]
 . Navigate to menu:Software[Manage > Channels].
-. Click btn:[Create Channel] and set these parameters:
+. Click btn:[Create Channel] and set these parameters.
 Ensure you use the correct {rhela} version:
 * In the [guimenu]``Channel Name`` field, type [systemitem]``Uyuni Client Tools for CentOS 7 (x86_64)``.
 * In the [guimenu]``Channel Label`` field, type [systemitem]``centos7-uyuni-client-x86_64``.

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -1,29 +1,41 @@
 [[clients-sleses]]
 = Registering {sleses} Clients
 
-This section contains information about registering traditional and Salt clients running {sleses} operating systems ({slesesa} for the rest of the guide)
+This section contains information about registering traditional and Salt clients running {sleses} ({slesesa}) operating systems.
 
-{slesesa} clients can be initally based {rhel} or {centos}.
+{slesesa} clients are based on {rhel} or {centos}.
 
-[WARNING]
+They are sometimes also called SLESES, RES or {redhat} {slesesa}.
+
+
+[IMPORTANT]
 ====
-{slesesa} clients are also called sometimes SLESES, RES or {redhat} {slesesa})
-For {rhel} based clients you are responsible for arranging access to {rhela} or {centos} base media repository installation media.
+You are responsible for arranging access to {redhat} or {centos} base media repositories and installation media.
+====
+
 ifeval::[{suma-content} == true]
-You must obtain support from {suse} for all your {slesesa} systems.
-endif::[]
-ifeval::[{uyuni-content} == true]
-{suse} does not provide support for {slesesa} systems on Uyuni.
-endif::[]
+[IMPORTANT]
 ====
+You must obtain support from {suse} for all your {slesesa} systems.
+====
+endif::[]
+
+
+ifeval::[{uyuni-content} == true]
+[IMPORTANT]
+====
+{suse} does not provide support for {slesesa} systems on {uyuni}.
+====
+endif::[]
+
+
 
 == Server Requirements
 
 Before you begin, check that your {productname} Server meets the requirements at xref:installation:hardware-requirements.adoc[].
 
-Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
-
-To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+Taskomatic uses one CPU core, and requires at least 3072{nbsp}MB of RAM.
+To ensure that taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, and add this line:
 
 ----
 taskomatic.java.maxmemory=3072
@@ -34,97 +46,121 @@ Restart Taskomatic:
 systemctl restart taskomatic
 ----
 
-== {slesesa} Channel Management
 
-[IMPORTANT]
-====
-Missing packages will cause your registration to fail.
-For {slesesa} clients, some required packages are contained on the {rhel} installation media or the {centos} installation media.
-Ensure you follow the whole procedure before trying to register any {slesesa} client
-====
 
-=== Add {slesesa} Product from SCC
+== Add Client Tools
 
-The {slesesa} product is provided by {scc}, including the client tools.
 
-[IMPORTANT]
-====
-Because the {slesesa} channels are particularly large, it can take up to 24 hours for an initial channel synchronization to complete.
-When you have completed the initial synchronization, we recommended you clone the channel before working with it.
-This provides you with a backup of the original synchronization data.
-====
+For {slesesa} clients, some required packages are contained on the {rhel} or {centos} installation media.
+You must have these packages installed before you can register a {slesesa} client.
+
+The {slesesa} product is provided by {scc}.
+This also includes the client tools package.
 
 Before you register {slesesa} clients to your {productname} Server, check that you have the corresponding {slesesa} product enabled, and the required channels are fully synchronized.
 
 You need to select two different sets of channels, one for {slesesa} and the other for the Client Tools.
 
-{slesesa} 6::
-* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools.
-* "RHEL Expanded Support 6" at the WebUI, or [systemitem]``res6-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
+You will need an activation key associated with the correct {slesesa} channels.
+For more information about activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
 
-// I suggest adding a screenshot
 
-{slesesa} 7::
-* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools.
-* "RHEL Expanded Support 7" at the WebUI, or [systemitem]``res7-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
 
-// I suggest adding screenshot
+.Procedure: Adding Client Tools Channels
 
-You can synchronize the channels with [command]``mgr-sync``.
+. On the {productname} Server, add the appropriate {slesesa} channels:
++
+* For {slesesa} 6:
++
+From the {webui}, add [systemitem]``RHEL6 Base x86_64`` and [systemitem]``SUSE Linux Enterprise Client Tools RES6 x86_64``.
++
+From the command prompt, add [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64``.
++
+* For {slesesa} 7:
++
+From the {webui}, add [systemitem]``RHEL7 Base x86_64`` and [systemitem]``SUSE Linux Enterprise Client Tools RES7 x86_64``.
++
+From the command prompt, add [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64``.
+.  Synchronize the {productname} Server with the {SCC}.
+You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt. to do it from CLI.
+. Add the new channel to your activation key.
+
 
 There are two ways to check if a channel has finished synchronizing:
 
-* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
+// This isn't included in the RH section, should it be (at ~L180) ? LKB 2019-09-30
+
+* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the [guimenu]``SUSE Products`` tab.
++
 This dialog displays a completion bar for each product when they are being synchronized.
-* You can also check the synchronization log file at the command prompt.
-
-Use the [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
-
-If you use this method, remember that base channels can contain multiple child channels.
-
-Each of the child channels will generate its own log during the synchronization progress.
-
+* Check the synchronization log file at the command prompt with [command]``tail -f /var/log/rhn/reposync/channel-label.log`` file.
++
+Each child channel will generate its own log during the synchronization progress.
 You will need to check all the base and child channel log files to be sure that the synchronization is complete.
 
-You will also need an activation key associated with the correct {slesesa} channels (6 or 7)
 
-For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+[NOTE]
+====
+The {slesesa} channels can be very large.
+The initial channel synchronization can sometimes take up to 24 hours.
 
-=== Add {rhel} or {centos} Media
+When the initial synchronization is complete, we recommended you clone the channel before you work with it.
+This gives you a backup of the original synchronization data.
+====
 
-The Base {slesesa} channel does not contain any packages.
 
-This is because {suse} does not provide {rhel} or {centos} base media.
 
-You will need to obtain base media from {redhat} or {centos}, which you can then add as a child channel to the {slesesa} parent channel.
+=== Add Base Media
 
-The following procedure guides you through setup of the {rhel} or {centos} media as a {productname} channel.
 
-All packages on the media will be mirrored into a child channel located under the distribution name and architecture.
+The base {slesesa} channel does not contain any packages, because {suse} does not provide {rhel} or {centos} base media.
+You will need to obtain base media from {redhat} or {centos}, which you can add as a child channel to the {slesesa} parent channel.
 
-.Procedure: Setting up a {rhel} or {centos} Channel
+You can use {productname} custom channels to set up the {rhel} or {centos} media.
+All packages on the base media are mirrored into a child channel.
 
-. In the {productname} {webui}, navigate to menu:Channels[Manage Software Channels], and click btn:[Create Channel].
-. Fill in the channel details, and add the channel as a child to the corresponding {rhel} or {centos} distribution channel for your architecture.
-The base parent channel will not contain any packages.
-. Modify the associated activation key to include your new child channel.
-. At the command prompt, as root, copy your installation disk image to the [path]``/tmp`` directory.
-. Create a directory to contain the media content (you can replace [path]``/rhel`` with [path]``/centos`` if you are using {centos}.
+
+
+.Procedure: Creating a {rhel} or {centos} Custom Channel
+
+. In the {productname} {webui}, navigate to menu:Software[Manage > Channels].
+. Click btn:[Create Channel] and set these parameters:
+* In the [guimenu]``Channel Name`` field, type a name for your channel, specifying the OS name and architecture.
+* In the [guimenu]``Channel Label`` field, type a label for your channel, specifying the OS name and architecture.
+* In the [guimenu]``Parent Channel`` field, select the corresponding {rhel} or {centos} distribution channel for your architecture.
+The parent channel will not contain any packages.
+* In the [guimenu]``Architecture`` field, select the appropriate architecture.
+* In the [guimenu]``Repository Checksum Type`` field, select [systemitem]``sha1``.
+* In the [guimenu]``Channel Summary`` field, type a summary for your channel, specifying the OS name and architecture.
+* In the [guimenu]``Organization Sharing`` field, select [systemitem]``Public``.
+. Click btn:[Create Channel].
+. Add the new channel to your activation key.
+
+
+When you have created the custom child channel, you can add the base media image to the channel.
+
+
+
+.Procedure: Adding Base Media to Custom Channels
+
+. On the {productname} Server command prompt, as root, copy the base media image to the [path]``/tmp`` directory.
+. Create a directory to contain the media content.
+Replace [command]``<os_name>`` with either ``rhel``  or ``centos``:
 +
 ----
-mkdir -p /srv/www/htdocs/pub/rhel
+mkdir -p /srv/www/htdocs/pub/<os_name>
 ----
-. Mount the ISO:
+. Mount the image:
 +
 ----
-mount -o loop /tmp/name_of_iso /srv/www/htdocs/pub/rhel
+mount -o loop /tmp/<iso_filename> /srv/www/htdocs/pub/<os_name>
 ----
-. Synchronize the packages with [command]``spacewalk-repo-sync``:
+. Synchronize the packages
 +
 For {rhel} or {centos} 7:
 +
 ----
-spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/
+spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/<os_name>/
 Repo URL: https://127.0.0.1/pub/rhel/
 Packages in repo:              [...]
 Packages already synced:       [...]
@@ -135,20 +171,22 @@ Packages to sync:              [...]
 For {rhel} or {centos} 6:
 +
 ----
-spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/Server/
-Repo URL: https://127.0.0.1/pub/rhel/Server/
-Packages in repo:              [...]
-Packages already synced:       [...]
-Packages to sync:              [...]
-[...]
+spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/<os_name>/Server/
 ----
 
-Sometimes, the [command]``spacewalk-repo-sync`` will stop running during a synchronization, which will give this error:
+
+
+=== Troubleshooting Synchronization
+
+// This isn't included in the RH section, should it be (at ~L260) ? LKB 2019-09-30
+
+Sometimes, the [command]``spacewalk-repo-sync`` command will stop running during a synchronization, and give this error:
+
 ----
 [Errno 256] No more mirrors to try.
 ----
 
-If this occurs, you can run [command]``spacewalk-repo-sync`` in debugging mode to determine the error.
+If this occurs, run [command]``spacewalk-repo-sync`` in debugging mode to determine the error.
 
 Start debugging mode:
 ----
@@ -165,6 +203,10 @@ Disable debug mode:
 unset URLGRABBER_DEBUG
 ----
 
+
+
 == Register {slesesa} Clients
 
-When you are ready to register your {slesesa} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].
+You {slesesa} clients are now ready to be registered.
+
+For more information on registering your clients, see xref:client-configuration:registration-overview.adoc[].

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 == Server Requirements
 
-Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
+Before you begin, check that your {productname} Server meets the requirements at xref:installation:hardware-requirements.adoc[].
 
 Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -17,7 +17,7 @@ ifeval::[{uyuni-content} == true]
 endif::[]
 ====
 
-== Server requirements
+== Server Requirements
 
 Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -82,7 +82,7 @@ From the {webui}, add [systemitem]``RHEL7 Base x86_64`` and [systemitem]``SUSE L
 +
 From the command prompt, add [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64``.
 .  Synchronize the {productname} Server with the {SCC}.
-You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt. to do it from CLI.
+You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt.
 . Add the new channel to your activation key.
 
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -43,7 +43,7 @@ For {slesesa} clients, some required packages are contained on the {rhel} instal
 Ensure you follow the whole procedure before trying to register any {slesesa} client
 ====
 
-=== Add {slesesa} product from SCC
+=== Add {slesesa} Product from SCC
 
 The {slesesa} product is provided by {scc}, including the client tools.
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -81,7 +81,7 @@ From the command prompt, add [systemitem]``rhel-x86_64-server-6`` and [systemite
 From the {webui}, add [systemitem]``RHEL7 Base x86_64`` and [systemitem]``SUSE Linux Enterprise Client Tools RES7 x86_64``.
 +
 From the command prompt, add [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64``.
-.  Synchronize the {productname} Server with the {SCC}.
+. Synchronize the {productname} Server with the {SCC}.
 You can do this using the {webui}, or by running [command]``mgr-sync`` at the command prompt.
 . Add the new channel to your activation key.
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -109,7 +109,7 @@ All packages on the media will be mirrored into a child channel located under th
 The base parent channel will not contain any packages.
 . Modify the associated activation key to include your new child channel.
 . At the command prompt, as root, copy your installation disk image to the [path]``/tmp`` directory.
-. Create a directory to contain the media content (you can replace [path]``/rhel`` with [path]``/centos`` if you are using {centos}
+. Create a directory to contain the media content (you can replace [path]``/rhel`` with [path]``/centos`` if you are using {centos}.
 +
 ----
 mkdir -p /srv/www/htdocs/pub/rhel

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -78,7 +78,7 @@ There are two ways to check if a channel has finished synchronizing:
 This dialog displays a completion bar for each product when they are being synchronized.
 * You can also check the synchronization log file at the command prompt.
 
-Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
+Use the [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
 
 If you use this method, remember that base channels can contain multiple child channels.
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -8,7 +8,7 @@ This section contains information about registering traditional and Salt clients
 [WARNING]
 ====
 {slesesa} clients are also called sometimes SLESES, RES or {redhat} {slesesa})
-For {rhel} based clients tou are responsible for arranging access to {rhela} or {centos} base media repositories installation media.
+For {rhel} based clients you are responsible for arranging access to {rhela} or {centos} base media repository installation media.
 ifeval::[{suma-content} == true]
 You must obtain support from {suse} for all your {slesesa} systems.
 endif::[]

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -7,7 +7,7 @@ This section contains information about registering traditional and Salt clients
 
 [WARNING]
 ====
-{slesesa} clients are also called sometimes SLESES, RES or {redhat} {slesa})
+{slesesa} clients are also called sometimes SLESES, RES or {redhat} {slesesa})
 For {rhel} based clients tou are responsible for arranging access to {rhela} or {centos} base media repositories installation media.
 ifeval::[{suma-content} == true]
 You must obtain support from {suse} for all your {slesesa} systems.
@@ -40,16 +40,19 @@ systemctl restart taskomatic
 ====
 Missing packages will cause your registration to fail.
 For {slesesa} clients, some required packages are contained on the {rhel} installation media or the {centos} installation media.
-Ensure you follow the whole procedure before trying to register any {slesa} client
+Ensure you follow the whole procedure before trying to register any {slesesa} client
 ====
 
 === Add {slesesa} product from SCC
 
 The {slesesa} product is provided by {scc}, including the client tools.
 
+[IMPORTANT]
+====
 Because the {slesesa} channels are particularly large, it can take up to 24 hours for an initial channel synchronization to complete.
 When you have completed the initial synchronization, we recommended you clone the channel before working with it.
 This provides you with a backup of the original synchronization data.
+====
 
 Before you register {slesesa} clients to your {productname} Server, check that you have the corresponding {slesesa} product enabled, and the required channels are fully synchronized.
 
@@ -59,13 +62,13 @@ You need to select two different sets of channels, one for {slesesa} and the oth
 * "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools.
 * "RHEL Expanded Support 6" at the WebUI, or [systemitem]``res6-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
 
-// I suggest adding scripts
+// I suggest adding a screenshot
 
 {slesesa} 7::
 * "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools.
 * "RHEL Expanded Support 7" at the WebUI, or [systemitem]``res7-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
 
-// I suggest adding scripts
+// I suggest adding screenshot
 
 You can synchronize the channels with [command]``mgr-sync``.
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -1,0 +1,167 @@
+[[clients-sleses]]
+= Registering {sleses} Clients
+
+This section contains information about registering traditional and Salt clients running {sleses} operating systems ({slesesa} for the rest of the guide)
+
+{slesesa} clients can be initally based {rhel} or {centos}.
+
+[WARNING]
+====
+{slesesa} clients are also called sometimes SLESES, RES or {redhat} {slesa})
+For {rhel} based clients tou are responsible for arranging access to {rhela} or {centos} base media repositories installation media.
+ifeval::[{suma-content} == true]
+You must obtain support from {suse} for all your {slesesa} systems.
+endif::[]
+ifeval::[{uyuni-content} == true]
+{suse} does not provide support for {slesesa} systems on Uyuni.
+endif::[]
+====
+
+== Server requirements
+
+Ensure that your {productname} Server meets the requirements outlined at xref:installation:hardware-requirements.adoc[].
+
+Taskomatic will use one CPU core, and requires at least 3072{nbsp}MB RAM.
+
+To ensure that Taskomatic has access to enough memory, open the [path]``/etc/rhn/rhn.conf`` configuration file, add this line:
+
+----
+taskomatic.java.maxmemory=3072
+----
+
+Restart Taskomatic:
+----
+systemctl restart taskomatic
+----
+
+== {slesesa} Channel Management
+
+[IMPORTANT]
+====
+Missing packages will cause your registration to fail.
+For {slesesa} clients, some required packages are contained on the {rhel} installation media or the {centos} installation media.
+Ensure you follow the whole procedure before trying to register any {slesa} client
+====
+
+=== Add {slesesa} product from SCC
+
+The {slesesa} product is provided by {scc}, including the client tools.
+
+Because the {slesesa} channels are particularly large, it can take up to 24 hours for an initial channel synchronization to complete.
+When you have completed the initial synchronization, we recommended you clone the channel before working with it.
+This provides you with a backup of the original synchronization data.
+
+Before you register {slesesa} clients to your {productname} Server, check that you have the corresponding {slesesa} product enabled, and the required channels are fully synchronized.
+
+You need to select two different sets of channels, one for {slesesa} and the other for the Client Tools.
+
+{slesesa} 6::
+* "RHEL6 Base x86_64" and "SUSE Linux Enterprise Client Tools RES6 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-6`` and [systemitem]``res6-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools.
+* "RHEL Expanded Support 6" at the WebUI, or [systemitem]``res6-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
+
+// I suggest adding scripts
+
+{slesesa} 7::
+* "RHEL7 Base x86_64" and "SUSE Linux Enterprise Client Tools RES7 x86_64" at the WebUI, or [systemitem]``rhel-x86_64-server-7`` and [systemitem]``res7-suse-manager-tools-x86_64`` at CLI. This adds the packages for the {slesesa} Client Tools.
+* "RHEL Expanded Support 7" at the WebUI, or [systemitem]``res7-x86_64`` at CLI. This adds the packages for the {slesesa} Operating System.
+
+// I suggest adding scripts
+
+You can synchronize the channels with [command]``mgr-sync``.
+
+There are two ways to check if a channel has finished synchronizing:
+
+* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the menu:SUSE Products[] tab.
+This dialog displays a completion bar for each product when they are being synchronized.
+* You can also check the synchronization log file at the command prompt.
+
+Use the [command]``cat`` or [command]``tail -f`` command to view the [path]``/var/log/rhn/reposync/channel-label.log`` file.
+
+If you use this method, remember that base channels can contain multiple child channels.
+
+Each of the child channels will generate its own log during the synchronization progress.
+
+You will need to check all the base and child channel log files to be sure that the synchronization is complete.
+
+You will also need an activation key associated with the correct {slesesa} channels (6 or 7)
+
+For more information on activation keys, see xref:client-configuration:clients-and-activation-keys.adoc[].
+
+=== Add {rhel} or {centos} Media
+
+The Base {slesesa} channel does not contain any packages.
+
+This is because {suse} does not provide {rhel} or {centos} base media.
+
+You will need to obtain base media from {redhat} or {centos}, which you can then add as a child channel to the {slesesa} parent channel.
+
+The following procedure guides you through setup of the {rhel} or {centos} media as a {productname} channel.
+
+All packages on the media will be mirrored into a child channel located under the distribution name and architecture.
+
+.Procedure: Setting up a {rhel} or {centos} Channel
+
+. In the {productname} {webui}, navigate to menu:Channels[Manage Software Channels], and click btn:[Create Channel].
+. Fill in the channel details, and add the channel as a child to the corresponding {rhel} or {centos} distribution channel for your architecture.
+The base parent channel will not contain any packages.
+. Modify the associated activation key to include your new child channel.
+. At the command prompt, as root, copy your installation disk image to the [path]``/tmp`` directory.
+. Create a directory to contain the media content (you can replace [path]``/rhel`` with [path]``/centos`` if you are using {centos}
++
+----
+mkdir -p /srv/www/htdocs/pub/rhel
+----
+. Mount the ISO:
++
+----
+mount -o loop /tmp/name_of_iso /srv/www/htdocs/pub/rhel
+----
+. Synchronize the packages with [command]``spacewalk-repo-sync``:
++
+For {rhel} or {centos} 7:
++
+----
+spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/
+Repo URL: https://127.0.0.1/pub/rhel/
+Packages in repo:              [...]
+Packages already synced:       [...]
+Packages to sync:              [...]
+[...]
+----
++
+For {rhel} or {centos} 6:
++
+----
+spacewalk-repo-sync -c channel_name -u https://127.0.0.1/pub/rhel/Server/
+Repo URL: https://127.0.0.1/pub/rhel/Server/
+Packages in repo:              [...]
+Packages already synced:       [...]
+Packages to sync:              [...]
+[...]
+----
+
+Sometimes, the [command]``spacewalk-repo-sync`` will stop running during a synchronization, which will give this error:
+----
+[Errno 256] No more mirrors to try.
+----
+
+If this occurs, you can run [command]``spacewalk-repo-sync`` in debugging mode to determine the error.
+
+Start debugging mode:
+----
+export URLGRABBER_DEBUG=DEBUG
+----
+
+Check the output:
+----
+/usr/bin/spacewalk-repo-sync --channel <channel-label> --type yum
+----
+
+Disable debug mode:
+----
+unset URLGRABBER_DEBUG
+----
+
+== Register {slesesa} Clients
+
+When you are ready to register your {slesesa} client, follow the instructions in xref:client-configuration:registration-overview.adoc[].

--- a/suma-site.yml
+++ b/suma-site.yml
@@ -47,7 +47,9 @@ asciidoc:
     ipf: Itanium
     x86: x86
     x86_64: x86_64
+    centos: 'CentOS'
     rhel: 'Red Hat Enterprise Linux'
+    rhela: 'RHEL'
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
     rhnminrelease7: 'Red Hat Enterprise Linux Server 7'
     ubuntu: Ubuntu
@@ -65,6 +67,8 @@ asciidoc:
     scc: SUSE Customer Center
     sls: SUSE Linux Enterprise Server
     sle: SUSE Linux Enterprise
+    sleses: SUSE Linux Enterprise Server with Expanded Support
+    slesesa: Expanded Support
     slsa: SLES
     suse: SUSE
     slea: SLE

--- a/suma-site.yml
+++ b/suma-site.yml
@@ -47,7 +47,7 @@ asciidoc:
     ipf: Itanium
     x86: x86
     x86_64: x86_64
-    centos: 'CentOS'
+    redhat: 'Red Hat'
     rhel: 'Red Hat Enterprise Linux'
     rhela: 'RHEL'
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
@@ -81,7 +81,6 @@ asciidoc:
     rootuser: root
     ruser: root
     mdash: '-'
-    rhela: RHEL
     mgradvtop: Advanced Topics Guide
     mgrgetstart: Getting Started Guide
     mgrrefguide: Reference Guide

--- a/uyuni-site.yml
+++ b/uyuni-site.yml
@@ -39,7 +39,9 @@ asciidoc:
     ipf: Itanium
     x86: x86
     x86_64: x86_64
+    centos: 'CentOS'
     rhel: 'Red Hat Enterprise Linux'
+    rhela: 'RHEL'
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
     rhnminrelease7: 'Red Hat Enterprise Linux Server 7'
     ubuntu: Ubuntu
@@ -57,6 +59,8 @@ asciidoc:
     scc: SUSE Customer Center
     sls: SUSE Linux Enterprise Server
     sle: SUSE Linux Enterprise
+    sleses: SUSE Linux Enterprise Server with Expanded Support
+    slesesa: Expanded Support
     slsa: SLES
     suse: SUSE
     slea: SLE

--- a/uyuni-site.yml
+++ b/uyuni-site.yml
@@ -39,7 +39,7 @@ asciidoc:
     ipf: Itanium
     x86: x86
     x86_64: x86_64
-    centos: 'CentOS'
+    redhat: 'Red Hat'
     rhel: 'Red Hat Enterprise Linux'
     rhela: 'RHEL'
     rhnminrelease6: 'Red Hat Enterprise Linux Server 6'
@@ -73,7 +73,6 @@ asciidoc:
     rootuser: root
     ruser: root
     mdash: '-'
-    rhela: RHEL
     mgradvtop: Advanced Topics Guide
     mgrgetstart: Getting Started Guide
     mgrrefguide: Reference Guide


### PR DESCRIPTION
General rework. Among other things:
- New `clients-sleses.adoc` for SUSE Linux Enterprise Server with Expanded Support (AKA RES, AKA Red Hat Expanded Support).
- `clients-rh.adoc` now discribes the procedure for real RHEL clients, with including how to connect the server to the CDN. The clients to be used are those for Expanded Support Client Tools for SUSE Manager, or Uyuni Client Tools for Uyuni (uses an `if`)
- `clients-centos.adoc` now describes how to onboard CentOS with Expanded Support Client Tools for SUSE Manager, or with Uyuni Client Tools for Uyuni (uses an `if`)

**IMPORTANT**: The CentOS part is NOT valid for 3.2 unless we backport changes for spacewalk-common-channels there.

I added `if` where needed so we can show the correct warnings for either SUSE Manager on Uyuni.

This PR will require adding the screenshots where I left comments, and for sure it will require checking for small typos, styling, etc :-)

For minor stuff, please do it directly at the PR.

If you have questions, please ask before changing :-)

**WARNING:** To review the `.adoc` files, I suggest you check the whole file, and not the diffs (go to 'Files changed' tab, then click `...` on the right side of the bar where the filename is, then `View file`)

Addresses:
- [ ] SUSE/spacewalk#9347