### PR TITLE
WIP: Ubuntu rework

### DIFF
--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -151,7 +151,7 @@ There are two ways to check if a channel has finished synchronizing:
 * In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the [guimenu]``SUSE Products`` tab.
 +
 This dialog displays a completion bar for each product when they are being synchronized.
-* Check the synchronization log file at the command prompt with [command]``tail -f /var/log/rhn/reposync/channel-label.log`` file.
+* Check the synchronization log file at the command prompt with [command]``tail -f /var/log/rhn/reposync/channel-label.log``.
 +
 Each child channel will generate its own log during the synchronization progress.
 You will need to check all the base and child channel log files to be sure that the synchronization is complete.

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -1,7 +1,6 @@
 [[clients-ubuntu]]
 = Registering {ubuntu} Clients
 
-
 This section contains information about registering Salt clients running {ubuntu} operating systems.
 
 {susemgr} supports {ubuntu} 16.04 LTS and 18.04 LTS Clients using Salt.
@@ -19,8 +18,8 @@ Supported features:
 * Configuration and state channels
 
 Bootstrapping is supported for starting {ubuntu} clients and performing initial state runs such as setting repositories and performing profile updates.
-However, the root user on {ubuntu} is disabled by default, so in order to use bootstrapping, you will require an existing user with [command]``sudo`` privileges for Python.
 
+However, the root user on {ubuntu} is disabled by default, so in order to use bootstrapping, you will require an existing user with [command]``sudo`` privileges for Python.
 
 Some actions are not yet supported:
 
@@ -31,7 +30,6 @@ Some actions are not yet supported:
 * If you use are using a repository from storage media (`server.susemanager.fromdir = ...` option in rhn.conf), Ubuntu Client Tools will not work.
 // Reason: RMT and SMT cannot mirror Debian repositories (yet) and so cannot create it in that directory the correct files.
 // We are waiting for SMT to release the feature/fix to mirror Debian repositories. When this has been done, this comment and the limitation above can be removed.
-
 
 [NOTE]
 ====
@@ -46,69 +44,26 @@ Some preparation is required before you can register {ubuntu} clients to the {pr
 // ifdef does not show the content for uyuni
 // ifeval works for displaying content
 
-ifeval::[{uyuni-content} == true]
-
 .Procedure: Adding the {ubuntu} Channels
 
-. Install the [package]``spacewalk-utils`` package:
-+
-----
-sudo zypper in spacewalk-utils
-----
-
-. At the command prompt on the {productname} Server, as root, add the {ubuntu} channels:
-+
-----
-sudo spacewalk-common-channels ubuntu-1804-pool-amd64-uyuni ubuntu-1804-amd64-main-uyuni \
-ubuntu-1804-amd64-main-update-uyuni ubuntu-1804-amd64-main-security-uyuni \
-ubuntu-1804-amd64-universe-uyuni ubuntu-1804-amd64-uyuni-client
-----
-. Synchronize the new custom channels.
-You can check the progress of your synchronization from the command line with this command:
-+
-----
-tail -f /var/log/rhn/reposync.log /var/log/rhn/reposync/*
-----
-. To use bootstrap with {ubuntu}, you will need to create a bootstrap repository.
-You can do this from the command line with [command]``mgr-create-bootstrap-repo``:
-+
-----
-mgr-create-bootstrap-repo --with-custom-channels
-----
-
-For more information on creating custom repositories, see xref:administration:channel-management.adoc[].
-
-endif::[]
-
+// SUSE Manager content
 ifeval::[{suma-content} == true]
+Before you begin, ensure you have the {ubuntu} product enabled, and have synchronized the {ubuntu} channels for {scc}:
 
+{ubuntu} 16.04::
+* "Ubuntu 16.04" and "SUSE Linux Enterprise Client Tools Ubuntu 1604 amd64" at the {webui}, or [systemitem]``ubuntu-16.04-pool-amd64`` and [systemitem]``ubuntu-16.04-suse-manager-tools-amd64`` at CLI.
 
-Before you begin, ensure you have the {ubuntu} product enabled, and have synchronized the {ubuntu} channels:
+{ubuntu} 18.04::
+* "Ubuntu 18.04" and "SUSE Linux Enterprise Client Tools Ubuntu 1804 amd64" at the {webui}, or [systemitem]``ubuntu-18.04-pool-amd64`` and [systemitem]``ubuntu-18.04-suse-manager-tools-amd64`` at CLI.
 
-For {ubuntu} 18.04:
-
-* Product: {ubuntu} Client 18.04
-* Mandatory channels: [systemitem]``ubuntu-18.04-pool-amd64``
-
-For {ubuntu} 16.04:
-
-* Product: {ubuntu} Client 16.04
-* Mandatory channels: [systemitem]``ubuntu-16.04-pool-amd64``
-
-[NOTE]
+[WARNING]
 ====
 The mandatory channels do not contain {ubuntu} upstream packages.
 The repositories and channels for synchronizing upstream content must be configured manually.
 ====
 
-
-
-// SUSE Manager specific instructions
-ifeval::[{suma-webui-content} == true]
-
-.Procedure: Preparing to Register {ubuntu} Clients with Custom Channels
-
 . Ensure that you have the appropriate software channels available on your system.
+
 In the {productname} {webui}, navigate to menu:Software[Channel List > All].
 You should see a base channel and a child channel for your architecture, for example:
 +
@@ -133,6 +88,7 @@ For `main-updates`:
 * Repository Type: deb
 
 . Create custom channels under the `pool` channel, mirroring the vendor channels.
+
 Ensure the custom channels you create have `AMD64 Debian` architecture.
 Create this structure:
 +
@@ -147,12 +103,41 @@ Create this structure:
 ----
 
 . Associate the custom channels with the appropriate custom repositories.
+endif::[]
+// End of SUSE Manager content
+// Uyuni specific instructions, in fact this works at SUSE Manager as well, but spacewalk-common-channels script is NOT supported
+ifeval::[{uyuni-content} == true]
+Install the spacewalk-utils package:
+----
+sudo zypper in spacewalk-utils
+----
+
+At the command prompt on the {productname} Server, as root, add the Ubuntu channels (change the version of the channel names to match your Ubuntu version):
+
+----
+sudo spacewalk-common-channels ubuntu-1804-pool-amd64-uyuni ubuntu-1804-amd64-main-uyuni \
+ubuntu-1804-amd64-main-update-uyuni ubuntu-1804-amd64-main-security-uyuni \
+ubuntu-1804-amd64-universe-uyuni ubuntu-1804-amd64-uyuni-client
+----
+endif::[]
+
 . Synchronize the new custom channels.
+
+You can should also consider creating a regular synchronization schedule.
+
 You can check the progress of your synchronization from the command line with this command:
 +
 ----
 tail -f /var/log/rhn/reposync.log /var/log/rhn/reposync/*
 ----
+
+[WARNING]
+====
+{ubuntu} OS channels can grow to be very large. Thus it can take several hours to complete mirroring.
+====
+
+.Procedure: Creating the bootstrap repository
+
 . To use bootstrap with {ubuntu}, you will need to create a bootstrap repository.
 You can do this from the command line with [command]``mgr-create-bootstrap-repo``:
 +
@@ -161,77 +146,11 @@ mgr-create-bootstrap-repo --with-custom-channels
 ----
 
 For more information on creating custom repositories, see xref:administration:channel-management.adoc[].
-endif::[]
 
-
-
-.Procedure: Preparing to Register {ubuntu} Clients with Spacewalk
-
-Before you begin, ensure you have installed the `spacewalk-common-channels` utility from the `spacewalk-utils` package.
-
-
-. Ensure that you have the appropriate software channels available on your system.
-In the {productname} {webui}, navigate to menu:Software[Channel List  > All].
-You should see a base channel and a child channel for your architecture, for example:
-+
-----
- ubuntu-18.04-pool for amd64
- |
- +- Ubuntu-18.04-SUSE-Manager-Tools for amd64
-----
-. Open the [path]``/etc/rhn/spacewalk-common-channels.ini`` file, and locate the sections that begin with [systemitem]``ubuntu`` and end with [systemitem]``main`` or [systemitem]``updates``.
-Change the `yumrepo_url` to an existing repository URL.
-Do not change the `ubuntu-$VERSION-pool-$ARCH` section.
-+
-----
-[ubuntu-1804-pool-amd64]
-; do not change
-label    = ubuntu-18.04-pool-amd64
-checksum = sha256
-archs    = amd64-deb
-repo_type = deb
-name     = ubuntu-18.04-pool for amd64
-gpgkey_url =
-gpgkey_id =
-gpgkey_fingerprint =
-yumrepo_url = http://localhost/pub/repositories/empty-deb/
-
-[ubuntu-1804-amd64-main]
-label    = ubuntu-1804-amd64-main
-checksum = sha256
-archs    = amd64-deb
-repo_type = deb
-name     = Ubuntu 18.04 LTS AMD64 Main
-base_channels = ubuntu-18.04-pool-amd64
-; change URL
-yumrepo_url = http://mirror.example.com/ubuntu/dists/bionic/main/binary-amd64/
-
-[ubuntu-1804-amd64-updates]
-label    = ubuntu-1804-amd64-main-updates
-name     = Ubuntu 18.04 LTS AMD64 Updates
-archs    = amd64-deb
-repo_type = deb
-checksum = sha256
-base_channels = ubuntu-18.04-pool-amd64
-; change URL
-yumrepo_url = http://mirror.example.com/ubuntu/dists/bionic-updates/main/binary-amd64/
-----
-+
-. Use the [command]``spacewalk-common-channels` command to create the required channels and repositories.
-Ensure you use the appropriate version number in this command, either [systemitem]``ubuntu-1604`` or [systeitem]``ubuntu-1804``:
-+
-----
-spacewalk-common-channels -u <admin_user> -p <admin_pass> -a amd64-deb -v 'ubuntu-1804*'
-----
-
-
-
-== Enable the {ubuntu} Root User
+.Procedure: Granting Root User Access
 
 The root user on {ubuntu} is disabled by default.
 You can enable it by editing the [filename]``sudoers`` file.
-
-.**Procedure: Granting Root User Access**
 
 . On the client, edit the [filename]``sudoers`` file:
 +

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -93,7 +93,7 @@ For example:
 * In the [guimenu]``Repository URL`` field, type [systemitem]``http://ubuntumirror.example.com/ubuntu/dists/bionic-updates/main/binary-amd64/``.
 * In the [guimenu]``Repository Type`` field, select [systemitem]``deb``.
 * Leave all other fields as the default values.
-. Click btn:[Create Repository]
+. Click btn:[Create Repository].
 
 
 

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -6,6 +6,12 @@ This section contains information about registering Salt clients running {ubuntu
 {susemgr} supports {ubuntu} 16.04 LTS and 18.04 LTS Clients using Salt.
 Traditional clients are not supported.
 
+[IMPORTANT]
+====
+Canonical does not endorse or support {susemgr}.
+====
+
+
 Supported features:
 
 * Bootstrapping
@@ -31,126 +37,135 @@ Some actions are not yet supported:
 // Reason: RMT and SMT cannot mirror Debian repositories (yet) and so cannot create it in that directory the correct files.
 // We are waiting for SMT to release the feature/fix to mirror Debian repositories. When this has been done, this comment and the limitation above can be removed.
 
-[NOTE]
-====
-Canonical does not endorse or support {susemgr}.
-====
 
-== Prepare to Register {ubuntu} Clients
+
+== Prepare to Register
 
 Some preparation is required before you can register {ubuntu} clients to the {productname} Server.
 
-// ifndef works for displaying content when building uyuni
-// ifdef does not show the content for uyuni
-// ifeval works for displaying content
 
-.Procedure: Adding the {ubuntu} Channels
+//ifeval::[{suma-content} == true]
 
-// SUSE Manager content
-ifeval::[{suma-content} == true]
 Before you begin, ensure you have the {ubuntu} product enabled, and have synchronized the {ubuntu} channels for {scc}:
 
-{ubuntu} 16.04::
-* "Ubuntu 16.04" and "SUSE Linux Enterprise Client Tools Ubuntu 1604 amd64" at the {webui}, or [systemitem]``ubuntu-16.04-pool-amd64`` and [systemitem]``ubuntu-16.04-suse-manager-tools-amd64`` at CLI.
+For {ubuntu} 16.04:
 
-{ubuntu} 18.04::
-* "Ubuntu 18.04" and "SUSE Linux Enterprise Client Tools Ubuntu 1804 amd64" at the {webui}, or [systemitem]``ubuntu-18.04-pool-amd64`` and [systemitem]``ubuntu-18.04-suse-manager-tools-amd64`` at CLI.
+* From the {webui}, add [systemitem]``Ubuntu 16.04`` and [systemitem]``SUSE Linux Enterprise Client Tools Ubuntu 1604 amd64``.
+* From the command prompt, add [systemitem]``ubuntu-16.04-pool-amd64`` and [systemitem]``ubuntu-16.04-suse-manager-tools-amd64``.
 
-[WARNING]
+For {ubuntu} 18.04:
+
+* From the {webui}, add [systemitem]``Ubuntu 18.04`` and [systemitem]``SUSE Linux Enterprise Client Tools Ubuntu 1804 amd64``.
+* From the command prompt, add [systemitem]``ubuntu-18.04-pool-amd64`` and [systemitem]``ubuntu-18.04-suse-manager-tools-amd64``.
+
+[NOTE]
 ====
 The mandatory channels do not contain {ubuntu} upstream packages.
 The repositories and channels for synchronizing upstream content must be configured manually.
 ====
 
-. Ensure that you have the appropriate software channels available on your system.
+
+
+== Repository and Channel Management
+
 
 In the {productname} {webui}, navigate to menu:Software[Channel List > All].
-You should see a base channel and a child channel for your architecture, for example:
-+
-----
- ubuntu-18.04-pool for amd64
- |
- +- Ubuntu-18.04-SUSE-Manager-Tools for amd64
-----
-. Create custom repositories to mirror the {ubuntu} packages.
+Verify that you have a base channel and a child channel for your architecture.
+
 For example:
-+
-For `main`:
 
-* Repository Label: ubuntu-bionic-main
-* Repository URL: http://ubuntumirror.example.com/ubuntu/dists/bionic/main/binary-amd64/
-* Repository Type: deb
-+
-For `main-updates`:
+* Base channel: [systemitem]``ubuntu-18.04-pool for amd64``
+* Child channel: [systemitem]``Ubuntu-18.04-SUSE-Manager-Tools for amd64``
 
-* Repository Label: ubuntu-bionic-main-updates
-* Repository URL: http://ubuntumirror.example.com/ubuntu/dists/bionic-updates/main/binary-amd64/
-* Repository Type: deb
 
-. Create custom channels under the `pool` channel, mirroring the vendor channels.
 
-Ensure the custom channels you create have `AMD64 Debian` architecture.
-Create this structure:
-+
-----
- ubuntu-18.04-pool for amd64 (vendor channel)
- |
- +- Ubuntu-18.04-SUSE-Manager-Tools for amd64 (vendor channel)
- |
- +- ubuntu-18.04-amd64-main (custom channel)
- |
- +- ubuntu-18.04-amd64-main-updates (custom channel)
-----
+.Procedure: Creating Custom Repositories
 
-. Associate the custom channels with the appropriate custom repositories.
+. On the {productname} Server {webui}, navigate to menu:Software[Manage > Repositories].
+. Click btn:[Create Repository] and set these parameters for the ``main`` repository:
+* In the [guimenu]``Repository Label`` field, type [systemitem]``ubuntu-bionic-main``.
+* In the [guimenu]``Repository URL`` field, type [systemitem]``http://ubuntumirror.example.com/ubuntu/dists/bionic/main/binary-amd64/``.
+* In the [guimenu]``Repository Type`` field, select [systemitem]``deb``.
+* Leave all other fields as the default values.
+. Click btn:[Create Repository]
+. Click btn:[Create Repository] and set these parameters for the ``main-updates`` repository:
+* In the [guimenu]``Repository Label`` field, type [systemitem]``ubuntu-bionic-main-updates``.
+* In the [guimenu]``Repository URL`` field, type [systemitem]``http://ubuntumirror.example.com/ubuntu/dists/bionic-updates/main/binary-amd64/``.
+* In the [guimenu]``Repository Type`` field, select [systemitem]``deb``.
+* Leave all other fields as the default values.
+. Click btn:[Create Repository]
+
+
+
+When you have created the repositories, you can create the custom channels.
+
+￼Ensure the custom channels you create have `AMD64 Debian` architecture.
+
+Your custom channels should use this structure:
+
+* Parent channel: [systemitem]``ubuntu-18.04-pool for amd64``
+* Child vendor channel: [systemitem]``Ubuntu-18.04-SUSE-Manager-Tools for amd64``
+* Child custom channel: [systemitem]``ubuntu-18.04-amd64-main``
+* Child custom channel: [systemitem]``ubuntu-18.04-amd64-main-updates``
+
+When you have the channels set up, associate each channel with the appropriate repository, and synchronize then channels.
+
 endif::[]
-// End of SUSE Manager content
-// Uyuni specific instructions, in fact this works at SUSE Manager as well, but spacewalk-common-channels script is NOT supported
+
+
+
 ifeval::[{uyuni-content} == true]
-Install the spacewalk-utils package:
+
+// Uyuni specific instructions, in fact this works at SUSE Manager as well, but spacewalk-common-channels script is NOT supported
+
+.Procedure: Adding the {ubuntu} Channels
+
+. At the command prompt on the {productname} Server, as root, install the [systemitem]``spacewalk-utils`` package:
++
 ----
 sudo zypper in spacewalk-utils
 ----
-
-At the command prompt on the {productname} Server, as root, add the Ubuntu channels (change the version of the channel names to match your Ubuntu version):
-
+. Add the {ubuntu} channels.
+Adjust the version of the channel names to match your {ubuntu} version:
++
 ----
 sudo spacewalk-common-channels ubuntu-1804-pool-amd64-uyuni ubuntu-1804-amd64-main-uyuni \
 ubuntu-1804-amd64-main-update-uyuni ubuntu-1804-amd64-main-security-uyuni \
 ubuntu-1804-amd64-universe-uyuni ubuntu-1804-amd64-uyuni-client
 ----
-endif::[]
-
 . Synchronize the new custom channels.
 
-You can should also consider creating a regular synchronization schedule.
+endif::[]
 
-You can check the progress of your synchronization from the command line with this command:
-+
-----
-tail -f /var/log/rhn/reposync.log /var/log/rhn/reposync/*
-----
 
-[WARNING]
+
+[NOTE]
 ====
-{ubuntu} OS channels can grow to be very large. Thus it can take several hours to complete mirroring.
+{ubuntu} channels can be very large.
+Synchronization can sometimes take several hours.
 ====
 
-.Procedure: Creating the bootstrap repository
 
-. To use bootstrap with {ubuntu}, you will need to create a bootstrap repository.
-You can do this from the command line with [command]``mgr-create-bootstrap-repo``:
+There are two ways to check if a channel has finished synchronizing:
+
+* In the {productname} {webui}, navigate to menu:Admin[Setup Wizard] and select the [guimenu]``SUSE Products`` tab.
 +
-----
-mgr-create-bootstrap-repo --with-custom-channels
-----
+This dialog displays a completion bar for each product when they are being synchronized.
+* Check the synchronization log file at the command prompt with [command]``tail -f /var/log/rhn/reposync/channel-label.log`` file.
++
+Each child channel will generate its own log during the synchronization progress.
+You will need to check all the base and child channel log files to be sure that the synchronization is complete.
 
-For more information on creating custom repositories, see xref:administration:channel-management.adoc[].
 
-.Procedure: Granting Root User Access
+
+== Root Access
 
 The root user on {ubuntu} is disabled by default.
 You can enable it by editing the [filename]``sudoers`` file.
+
+
+
+.Procedure: Granting Root User Access
 
 . On the client, edit the [filename]``sudoers`` file:
 +
@@ -161,5 +176,18 @@ sudo visudo
 Grant [command]``sudo`` access to the user by adding this line to the [filename]``sudoers`` file. Replace [systemitem]``<user>`` with the name of the user that will be used to bootstrap the client in the {webui}:
 +
 ----
-<user>   ALL=NOPASSWD: /usr/bin/python, /usr/bin/python2, /usr/bin/python3
+<user>  ALL=NOPASSWD: /usr/bin/python, /usr/bin/python2, /usr/bin/python3
 ----
+
+
+
+== Register Clients
+
+. To register your {ubuntu} clients, you will need a bootstrap repository.
+Create the bootstrap repository at the command prompt, with this command:
++
+----
+mgr-create-bootstrap-repo --with-custom-channels
+----
+
+For more information on registering your clients, see xref:client-configuration:registration-overview.adoc[].

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -43,8 +43,9 @@ Some actions are not yet supported:
 
 Some preparation is required before you can register {ubuntu} clients to the {productname} Server.
 
-
 ifeval::[{suma-content} == true]
+
+.Procedure: Adding client tools channels
 
 Before you begin, ensure you have the {ubuntu} product enabled, and have synchronized the {ubuntu} channels for {scc}:
 
@@ -64,11 +65,6 @@ The mandatory channels do not contain {ubuntu} upstream packages.
 The repositories and channels for synchronizing upstream content must be configured manually.
 ====
 
-
-
-== Repository and Channel Management
-
-
 In the {productname} {webui}, navigate to menu:Software[Channel List > All].
 Verify that you have a base channel and a child channel for your architecture.
 
@@ -76,8 +72,6 @@ For example:
 
 * Base channel: [systemitem]``ubuntu-18.04-pool for amd64``
 * Child channel: [systemitem]``Ubuntu-18.04-SUSE-Manager-Tools for amd64``
-
-
 
 .Procedure: Creating Custom Repositories
 
@@ -94,8 +88,6 @@ For example:
 * In the [guimenu]``Repository Type`` field, select [systemitem]``deb``.
 * Leave all other fields as the default values.
 . Click btn:[Create Repository].
-
-
 
 When you have created the repositories, you can create the custom channels.
 
@@ -115,7 +107,6 @@ When you have the channels set up, associate each channel with the appropriate r
 You need all the new channels fully syncronized before bootstraping any Ubuntu client.
 ====
 endif::[]
-
 
 
 ifeval::[{uyuni-content} == true]

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -110,6 +110,10 @@ Your custom channels should use this structure:
 
 When you have the channels set up, associate each channel with the appropriate repository, and synchronize then channels.
 
+[IMPORTANT]
+====
+You need all the new channels fully syncronized before bootstraping any Ubuntu client.
+====
 endif::[]
 
 
@@ -135,16 +139,17 @@ ubuntu-1804-amd64-universe-uyuni ubuntu-1804-amd64-uyuni-client
 ----
 . Synchronize the new custom channels.
 
+[IMPORTANT]
+====
+You need all the new channels fully syncronized, including Universe (Universe contains important dependencies for salt), before bootstraping any Ubuntu client.
+====
 endif::[]
-
-
 
 [NOTE]
 ====
 {ubuntu} channels can be very large.
 Synchronization can sometimes take several hours.
 ====
-
 
 There are two ways to check if a channel has finished synchronizing:
 

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -99,7 +99,7 @@ For example:
 
 When you have created the repositories, you can create the custom channels.
 
-￼Ensure the custom channels you create have `AMD64 Debian` architecture.
+Ensure the custom channels you create have `AMD64 Debian` architecture.
 
 Your custom channels should use this structure:
 

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -44,7 +44,7 @@ Some actions are not yet supported:
 Some preparation is required before you can register {ubuntu} clients to the {productname} Server.
 
 
-//ifeval::[{suma-content} == true]
+ifeval::[{suma-content} == true]
 
 Before you begin, ensure you have the {ubuntu} product enabled, and have synchronized the {ubuntu} channels for {scc}:
 

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -156,7 +156,28 @@ This dialog displays a completion bar for each product when they are being synch
 Each child channel will generate its own log during the synchronization progress.
 You will need to check all the base and child channel log files to be sure that the synchronization is complete.
 
+ifeval::[{uyuni-content} == true]
 
+== Trust GPG Keys on Clients
+
+By default, {ubuntu} does not trust the GPG key for {productname} {ubuntu} client tools.
+
+The clients can be successfully bootstrapped without the GPG key being trusted.
+
+However, they will not be able to install new client tool packages or update them.
+
+To fix this, add this key to the [systemitem]``ORG_GPG_KEY=`` parameter in all {ubuntu} bootstrap scripts:
+----
+uyuni-gpg-pubkey-0d20833e.key
+----
+
+You do not need to delete any previously stored keys.
+
+If you are boostrapping clients from the {productname} {webui}, you will need to use a salt state to trust the key.
+Create the salt state and assign it to the organization.
+You can then use an activation key and configuration channels to deploy the key to the clients.
+
+endif::[]
 
 == Root Access
 


### PR DESCRIPTION
- Manual procedure for SUSE Manager (`spacewalk-common-channels` not supported yet)
- "Automated" procedure for Uyuni
- Fix the `if`s, now SUSE Manager goes first, Uyuni second, and the `if`s only happen for the content that is really different.

Feel free to edit directly at the PR for minor stuff. Reserve the comments only for doubts or big stuff.