### PR TITLE
Tech review of client contact methods(contact-methods.adoc)

### DIFF
--- a/modules/client-configuration/pages/contact-methods.adoc
+++ b/modules/client-configuration/pages/contact-methods.adoc
@@ -40,6 +40,16 @@ The default interval time is four hours (240 minutes).
 The minimum allowed time interval is one hour (60 minutes).
 If you set the interval below one hour, it will change back to the default of 4 hours (240 minutes).
 
+If you modify the `rhnsd` configuration file, execute this command as root to restart the daemon and pick up your changes:
+----
+/etc/init.d/rhnsd restart
+----
+
+To see the status of `rhnsd`, use this command as root:
+----
+/etc/init.d/rhnsd status
+----
+
 On {sle}{nbsp}12 and later, the default time interval is set in [path]``/etc/systemd/system/timers.target.wants/rhnsd.timer``, in this section:
 
 ----
@@ -64,16 +74,6 @@ OnCalendar=00/2:00
 The file will be saved as [path]``/etc/systemd/system/rhnsd.timer.d/override.conf``.
 
 For more information about system timers, see the [command]``systemd.timer`` and [command]``systemctl`` manpages.
-
-If you modify the `rhnsd` configuration file, execute this command as root to restart the daemon and pick up your changes:
-----
-/etc/init.d/rhnsd restart
-----
-
-To see the status of `rhnsd`, use this command as root:
-----
-/etc/init.d/rhnsd status
-----
 
 
 

--- a/modules/client-configuration/pages/contact-methods.adoc
+++ b/modules/client-configuration/pages/contact-methods.adoc
@@ -136,7 +136,7 @@ For security reasons, you might want to use sudo with SSH, to access the system 
 
 .Procedure: Configuring Unprivileged SSH Access
 . Ensure you have the latest [path]``spacewalk-taskomatic`` and [path]``spacewalk-certs-tools`` packages installed on the {productname} Server.
-. On each client system, create an appropriate unprivileged user on each client system.
+. On each client system, create an appropriate unprivileged user.
 . On each client system, open the [path]``/etc/sudoers`` file and comment out these lines:
 +
 ----
@@ -360,7 +360,7 @@ OSAD clients use the fully qualified domain name (FQDN) of the server to communi
 SSL is required for [systemitem]``osad`` communication.
 If SSL certificates are not available, the daemon on your client systems will fail to connect.
 Make sure your firewall rules are set to allow the required ports.
-For more information, see <<tab.install.ports.server>>.
+For more information, see  xref:installation:ports.adoc[].
 
 
 .Procedure: Enabling OSAD
@@ -409,7 +409,7 @@ jabbersoftnofile5100
 jabberhardnofile6000
 ----
 
-Calculate the limits required for your environment by adding 100 to the number of clients for the soft limit, and 1000 to the current number of clients for the soft limit.
+Calculate the limits required for your environment by adding 100 to the number of clients for the soft limit, and 1000 to the current number of clients for the hard limit.
 In the example above, we have assumed 500 current clients, so the soft limit is 5100, and the hard limit is 6000.
 
 You will also need to update the [systemitem]``max_fds`` parameter in the [path]``/etc/jabberd/c2s.xml`` file with your chosen hard limit:


### PR DESCRIPTION
This page is already in pretty good condition and upto-date. I just found small typos and moved around a paragraph where we were switching context between sles11 and sles12 onward and it was a bit confusing. Also  [tab.install.ports.server] link is broken, I would have fixed it but couldn't find where it should have been pointed to.
