### PR TITLE
make systemdata copying an optionally substep of the migration

### DIFF
--- a/modules/upgrade/pages/migrate-3x-4x.adoc
+++ b/modules/upgrade/pages/migrate-3x-4x.adoc
@@ -22,6 +22,7 @@ We strongly recommend that you contact SUSE Consulting to assist with this proce
 ====
 
 
+
 == Prepare to Migrate
 
 The source system must be running {productname} 3.2 with all the latest updates applied.
@@ -33,7 +34,7 @@ It is important that PostgreSQL 10 is already running on your {productname} 3.
 For more information, see xref:db-migration.adoc[].
 ====
 
-During migration, the database on the source system needs to get exported, or dumped.
+During migration, the database on the source system needs to get dumped.
 The dump is compressed, and temporarily stored on the target system.
 The compression is done using [command]``gzip`` using the default compression options.
 Maximum compression only yields about 10% of space savings.
@@ -85,6 +86,9 @@ Do not change the hostname during the process.
 Be careful when you log in to your systems during migration, as they will both show the same hostname.
 ====
 
+To speed up the actual migration and thus reducing the database downtime, you can copy the system data in advance.
+For more information, see <<migration.troubleshooting.systemdata>>.
+
 
 
 == Migration
@@ -108,7 +112,14 @@ When you have received the `migration successful`` message, you need to reconfig
 You will also need to restart the target system before it can be used.
 
 
-== Copy Data to the Target System
+
+[[migration.troubleshooting]]
+== Troubleshooting
+
+
+
+[[migration.troubleshooting.systemdata]]
+==== Copy System Data to the Target System
 
 A complete migration can consume a lot of time.
 This is caused by the amount of data that must be copied.
@@ -143,6 +154,10 @@ The second time you run the command, only the data that has changed will be tran
 While the data migration is in progress, the database services will be shut down.
 This is to ensure that no data is written to the database during the migration.
 
+
+
+[[migration.troubleshooting.pkgdata]]
+=== Intergrate Externally Stored Package Data
 
 .Procedure: Migrating Data on an External Storage Device
 

--- a/modules/upgrade/pages/migrate-3x-4x.adoc
+++ b/modules/upgrade/pages/migrate-3x-4x.adoc
@@ -34,8 +34,8 @@ It is important that PostgreSQL 10 is already running on your {productname} 3.
 For more information, see xref:db-migration.adoc[].
 ====
 
-During migration, the database on the source system needs to get dumped.
-The dump is compressed, and temporarily stored on the target system.
+During migration, the database on the source system needs to get exported.
+The database export is compressed, and temporarily stored on the target system.
 The compression is done using [command]``gzip`` using the default compression options.
 Maximum compression only yields about 10% of space savings.
 Before you begin, use this command on the source system to check the size of the database:
@@ -46,7 +46,7 @@ du -sch /var/lib/pgsql/data
 Ensure you have at least 30% of the total database size available in [path]``/var/spacewalk/tmp`` on the target system.
 
 The [path]``/var/spacewalk/tmp`` directory will be created if it does not exist.
-If you want the dump to be stored somewhere else, change the [var]``$TMPDIR`` variable at the beginning of the migration script.
+If you want the export to be stored somewhere else, change the [var]``$TMPDIR`` variable at the beginning of the migration script.
 
 
 
@@ -124,7 +124,7 @@ You will also need to restart the target system before it can be used.
 A complete migration can consume a lot of time.
 This is caused by the amount of data that must be copied.
 
-These numbers from a test installation illustrate the approximate time it takes to dump and import a small 1.8{nbsp}GB database:
+These numbers from a test installation illustrate the approximate time it takes to export and import a small 1.8{nbsp}GB database:
 ----
 14:53:37   Dumping remote database to /var/spacewalk/tmp/susemanager.dmp.gz on target system. Please wait...
 14:58:14   Database successfully dumped. Size is: 506M
@@ -132,7 +132,7 @@ These numbers from a test installation illustrate the approximate time it takes 
 15:05:11   Database dump successfully imported.
 ----
 
-In this example, dumping the database took around five minutes, and importing the dump onto the target system took an additional seven minutes.
+In this example, exporting the database took around five minutes, and importing the export onto the target system took an additional seven minutes.
 For big installations this can take up to several hours.
 
 You also need to account for the time it takes to copy all the package data to the target system.

--- a/modules/upgrade/pages/migrate-3x-4x.adoc
+++ b/modules/upgrade/pages/migrate-3x-4x.adoc
@@ -159,7 +159,7 @@ This is to ensure that no data is written to the database during the migration.
 
 
 [[migration.troubleshooting.pkgdata]]
-=== Intergrate Externally Stored Package Data
+=== Integrate Externally Stored Package Data
 
 .Procedure: Migrating Data on an External Storage Device
 

--- a/modules/upgrade/pages/migrate-3x-4x.adoc
+++ b/modules/upgrade/pages/migrate-3x-4x.adoc
@@ -116,13 +116,15 @@ You will also need to restart the target system before it can be used.
 [[migration.troubleshooting]]
 == Troubleshooting
 
+A complete migration can consume a lot of time.
+This is caused by the amount of data that must be copied.
+Here are some hints how you can compensate it.
+
 
 
 [[migration.troubleshooting.systemdata]]
-==== Copy System Data to the Target System
+=== Copy System Data to the Target System
 
-A complete migration can consume a lot of time.
-This is caused by the amount of data that must be copied.
 
 These numbers from a test installation illustrate the approximate time it takes to export and import a small 1.8{nbsp}GB database:
 ----


### PR DESCRIPTION
Hubert, do you think it makes sense to restructure this chapter this way?  I'd like to have the 'mgr-setup -r' step part of the "normal" migration procedure, just optionally.