### PR TITLE
Technical review: Admin guide: Inter Server Sync

### DIFF
--- a/modules/administration/pages/iss.adoc
+++ b/modules/administration/pages/iss.adoc
@@ -12,7 +12,7 @@ If conflicting configurations exist, the system will prioritize the master confi
 . In the {productname} {webui}, navigate to menu:Admin[ISS Configuration > Slave Setup], and click btn:[Add new master].
 . In the [guimenu]``Details for new Master`` dialog, provide these details for the server to use as the ISS master:
 
-* In the [guimenu]``Master Fully-Qualified Domain Name`` field, enter the FQDN of the ISS master (for example: [systemitem]``http://server1.example.com``).
+* In the [guimenu]``Master Fully-Qualified Domain Name`` field, enter the FQDN of the ISS master (for example: [systemitem]``server1.example.com``).
 * In the [guimenu]``Filename of this Master's CA Certificate`` field, enter the absolute  path to the CA certificate on the ISS master (for example: [systemitem]``/etc/pki/trust/anchors-org-ssl``).
 Click btn:[Add new master] to add the ISS master.
 
@@ -21,7 +21,7 @@ Click btn:[Add new master] to add the ISS master.
 . In the {productname} {webui}, navigate to menu:Admin[ISS Configuration > Master Setup], and click btn:[Add new slave].
 . In the [guimenu]``Edit Slave Details`` dialog, for the server to use as the ISS slave provide these details:
 
-* In the [guimenu]``Slave Fully-Qualified Domain Name`` field, enter the FQDN of the ISS slave (for example: [systemitem]``http://server2.example.com``).
+* In the [guimenu]``Slave Fully-Qualified Domain Name`` field, enter the FQDN of the ISS slave (for example: [systemitem]``server2.example.com``).
 * Check the [guimenu]``Allow Slave to Sync?`` checkbox to enable the slave to synchronize with the master.
 * Check the [guimenu]``Sync All Orgs to Slave?`` checkbox to synchronize all organizations to this slave.
 . Click btn:[Create] to add the ISS slave.

--- a/modules/administration/pages/iss.adoc
+++ b/modules/administration/pages/iss.adoc
@@ -13,7 +13,7 @@ If conflicting configurations exist, the system will prioritize the master confi
 . In the [guimenu]``Details for new Master`` dialog, provide these details for the server to use as the ISS master:
 
 * In the [guimenu]``Master Fully-Qualified Domain Name`` field, enter the FQDN of the ISS master (for example: [systemitem]``server1.example.com``).
-* In the [guimenu]``Filename of this Master's CA Certificate`` field, enter the absolute  path to the CA certificate on the ISS master (for example: [systemitem]``/etc/pki/trust/anchors-org-ssl``).
+* In the [guimenu]``Filename of this Master's CA Certificate`` field, enter the absolute  path to the CA certificate on the ISS master (for example: [systemitem]``/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT``).
 Click btn:[Add new master] to add the ISS master.
 
 .Procedure: Setting up an ISS Slave


### PR DESCRIPTION
fixes for minor errors encountered during the review.

TODO after merging: check that the FQDNs (`server1.example.com`) are **not** rendered as links. This was the case before and it was wrong:

![ss](https://user-images.githubusercontent.com/1412268/66293609-556ff200-e8e7-11e9-8a8e-de8044603549.png)
