### PR TITLE
Update the button name for creating an AK in clients-and-activation-keys.adoc

### DIFF
--- a/modules/client-configuration/pages/clients-and-activation-keys.adoc
+++ b/modules/client-configuration/pages/clients-and-activation-keys.adoc
@@ -40,7 +40,7 @@ For more information, see xref:reference:systems/activation-keys.adoc[].
 . Select the child channels you need (for example, the mandatory {susemgr} tools and updates channels).
 . We recommend you leave the [guimenu]``Contact Method`` set to [guimenu]``Default``.
 . We recommend you leave the [guimenu]``Universal Default`` setting unchecked.
-. Click btn:[Update Activation Key] to create the activation key.
+. Click btn:[Create Activation Key] to create the activation key.
 . Check the [guimenu]``Configuration File Deployment`` check box to enable configuration management for this key, and click btn:[Update Activation Key] to save this change.
 
 [NOTE]


### PR DESCRIPTION
The button for creating an Activation Key is "Create Activation Key" instead of "Update Activation Key".