### PR TITLE
Update migrate-3x-4x.adoc

### DIFF
--- a/modules/upgrade/pages/migrate-3x-4x.adoc
+++ b/modules/upgrade/pages/migrate-3x-4x.adoc
@@ -140,7 +140,7 @@ For big installations this can take up to several hours.
 You also need to account for the time it takes to copy all the package data to the target system.
 Depending on your network infrastructure and hardware, this can also take a significant amount of time.
 
-You can copy the data at any time before or after the migration process.
+You can copy the data at any time before the migration process.
 Copying the data before you migrate can significantly reduce the amount of downtime required.
 
 .Procedure: Migrating System Data


### PR DESCRIPTION
The copying of packages can only happen *before* the actual migration. During the migration, the script will always perform a "rsync", so anything not yet copied will be transferred. Ideally, there should not be anything if the admin ensured already everything has been copied. But if (s)he chooses not to copy any data before the actual migration, EVERYTHING will be copied during the migration. So in short, once the customer has run "mgr-setup -m", there is nothing left to do regarding copying anything.