### PR TITLE
Update migrate-3x-4x.adoc

### DIFF
--- a/modules/upgrade/pages/migrate-3x-4x.adoc
+++ b/modules/upgrade/pages/migrate-3x-4x.adoc
@@ -150,8 +150,6 @@ Copying the data before you migrate can significantly reduce the amount of downt
 ----
 mgr-setup -r
 ----
-. If you have run this command before you performed the migration, ensure you run the command again afterwards.
-The second time you run the command, only the data that has changed will be transferred.
 
 While the data migration is in progress, the database services will be shut down.
 This is to ensure that no data is written to the database during the migration.


### PR DESCRIPTION
This probably should have been part of the previous commit. As explained there, the migration script will always implicitly run the rsync (that is triggered manually via "mgr-setup -r"), so there is no point running it again after the successful migration.