### PR TITLE
Update db-migration.adoc

### DIFF
--- a/modules/upgrade/pages/db-migration.adoc
+++ b/modules/upgrade/pages/db-migration.adoc
@@ -33,7 +33,7 @@ You cannot migrate directly from PostgreSQL{nbsp}9.4 to version 10.
 
 Before you begin the upgrade, prepare your existing 3.2 system and create a database backup.
 
-PostgreSQL stores data at [path]``/var/lib/pgsql/data/``, and logs to [path]``/var/lib/pgsql/data/pg_xlog/``.
+PostgreSQL stores data at [path]``/var/lib/pgsql/data/``.
 
 .Procedure: Preparing to Upgrade
 


### PR DESCRIPTION
The place where transaction logs are stored is not really relevant for the user. I propose just hiding this technical detail from the customer; it is not something she needs to know. Moreover, the path has changed in with postgresql10, so it would have been true only for versions up to 9.6