### PR TITLE
Registration: add a line for registering against the proxy

### DIFF
--- a/modules/client-configuration/pages/registration-webui.adoc
+++ b/modules/client-configuration/pages/registration-webui.adoc
@@ -14,6 +14,7 @@ By default, the SSH  port is [systemitem]``22``.
 By default, the username is [systemitem]``root``.
 . In the [guimenu]``Password`` field, type password to log in to the client.
 . In the [guimenu]``Activation Key`` field, select the activation key that is associated with the software channel you want to use to bootstrap the client.
+. OPTIONAL: In the [guimenu]``Proxy`` field, select the proxy to register the client to.
 . By default, the [guimenu]``Disable SSH Strict Key Host Checking`` checkbox is selected.
 This allows the bootstrap process to automatically accept SSH host keys without requiring you to manually authenticate.
 . OPTIONAL: Check the [guimenu]``Manage System Completely via SSH`` checkbox.


### PR DESCRIPTION
This page is also in good condition. It was just missing a line about the proxy field in case, the user wants to register the system against it.


