### PR TITLE
Update troubleshooting.adoc

### DIFF
--- a/modules/upgrade/pages/troubleshooting.adoc
+++ b/modules/upgrade/pages/troubleshooting.adoc
@@ -47,21 +47,6 @@ Reboot the server to pick up the changes.
 
 
 
-== Corrupted Database Dump
-
-If you think your database dump has been corrupted, you can check by using this command with the hostname of the source system:
-
-----
-ssh root@source_hostname "su -s /bin/bash - postgres -c exit"
-----
-
-The command will only produce output if the database has become corrupted.
-
-If the database is corrupted, check the [path]``.bashrc`` environment file on the source system.
-Ensure there is no extra text in the file at the point that the script starts the shell.
-
-
-
 == Retrying to Set up the Target System
 
 If you need to retry setting up the target system, follow these steps:


### PR DESCRIPTION
The migration script is doing this since quite a time now always to ensure silent remote command execution, so this should not happen anymore. In case the script detects that this condition is not met, it will stop and tell the admin anyway.