### PR TITLE
Change the default value for taskomatic to 4GB

### DIFF
--- a/modules/salt/pages/large-scale-tuning.adoc
+++ b/modules/salt/pages/large-scale-tuning.adoc
@@ -292,8 +292,8 @@ This section contains information about the available parameters.
 | Description          | The maximum amount of memory Taskomatic can use.
                          Generation of metadata, especially for some OSs, can be memory-intensive, so this parameter might need raising depending on the managed xref:os-mix[OS mix].
 | Tune when            | xref:java-taskomatic-channel-repodata-workers[`java.taskomatic_channel_repodata_workers`] increases, OSs are added to {productname} (particularly {rhel} or {ubuntu}), or `OutOfMemoryException` errors appear in `/var/log/rhn/rhn_taskomatic_daemon.log`.
-| Value default        | 2048 MiB
-| Value recommendation | 2048-16384 MiB
+| Value default        | 4096 MiB
+| Value recommendation | 4096-16384 MiB
 | Location             | [path]``/etc/rhn/rhn.conf``
 | Example              | `taskomatic.java.maxmemory = 8192`
 | After changing       | Check xref:memory-usage[memory usage].


### PR DESCRIPTION
This PR changes the default value for max memory of taskomatic to 4GB