### PR TITLE
Review of Salt guide (Round 1)

### DIFF
--- a/modules/salt/nav-salt-guide.adoc
+++ b/modules/salt/nav-salt-guide.adoc
@@ -4,8 +4,8 @@ ifndef::backend-pdf[]
 * Salt Guide
 ** xref:salt-intro.adoc[Introduction]
 ** xref:salt-terminology.adoc[Terminology]
-** xref:salt-calls.adoc[Salt Calls]
-** xref:salt-useful-commands.adoc[Salt Commands]
+** xref:salt-command.adoc[Salt Command]
+** xref:salt-useful-commands.adoc[Salt Useful Commands]
 ** xref:salt-states.adoc[Salt States]
 ** xref:salt-file-locations.adoc[File Locations]
 // Formulas
@@ -42,7 +42,7 @@ include::modules/salt/pages/salt-intro.adoc[leveloffset=+1]
 
 include::modules/salt/pages/salt-terminology.adoc[leveloffset=+1]
 
-include::modules/salt/pages/salt-calls.adoc[leveloffset=+1]
+include::modules/salt/pages/salt-command.adoc[leveloffset=+1]
 
 include::modules/salt/pages/salt-useful-commands.adoc[leveloffset=+1]
 

--- a/modules/salt/nav-salt-guide.adoc
+++ b/modules/salt/nav-salt-guide.adoc
@@ -5,7 +5,7 @@ ifndef::backend-pdf[]
 ** xref:salt-intro.adoc[Introduction]
 ** xref:salt-terminology.adoc[Terminology]
 ** xref:salt-calls.adoc[Salt Calls]
-** xref:salt-commands.adoc[Salt Commands]
+** xref:salt-useful-commands.adoc[Salt Commands]
 ** xref:salt-states.adoc[Salt States]
 ** xref:salt-file-locations.adoc[File Locations]
 // Formulas
@@ -44,7 +44,7 @@ include::modules/salt/pages/salt-terminology.adoc[leveloffset=+1]
 
 include::modules/salt/pages/salt-calls.adoc[leveloffset=+1]
 
-include::modules/salt/pages/salt-commands.adoc[leveloffset=+1]
+include::modules/salt/pages/salt-useful-commands.adoc[leveloffset=+1]
 
 include::modules/salt/pages/salt-states.adoc[leveloffset=+1]
 

--- a/modules/salt/pages/salt-command.adoc
+++ b/modules/salt/pages/salt-command.adoc
@@ -1,7 +1,7 @@
-[[salt.calls]]
-= Salt Calls
+[[salt.command]]
+= The Salt Command
 
-Salt calls have three main components: target, function, and arguments.
+A Salt command have three main components: target, function, and arguments.
 The calls are constructed in this format:
 ----
 salt 'target' <function> [arguments]
@@ -14,9 +14,9 @@ The function is the particular task to be run.
 Arguments provide any extra data required by the function.
 
 
-== Salt Call Targets
+== Salt Targets
 
-Salt call targets allow you to specify a client or group of clients.
+Salt command targets allow you to specify a client or group of clients.
 There are several different targets you can use.
 
 General Targeting::
@@ -87,22 +87,22 @@ For more on targeting, see https://docs.saltstack.com/en/latest/topics/targeting
 
 
 
-== Salt Call Functions
+== Salt Execution Modules
 
-When you have specified a target, provide the function to call on the target.
+When you have specified a target, provide the module to execute on the target.
 
-Find which functions can be called on the target:
+Find which modules can be executed on the target:
 ----
 salt '*' sys.doc
 ----
 
-For a full list of callable functions, see https://docs.saltstack.com/en/latest/ref/modules/all/index.html.
+For a full list of callable modules, see https://docs.saltstack.com/en/latest/ref/modules/all/index.html.
 
 
 
-== Salt Call Arguments
+== Salt Modules Arguments
 
-Functions accept arguments for any extra data.
+Modules accept arguments for any extra data.
 
 For example, the [command]``pkg.install`` function requires an argument specifying which package to install:
 ----

--- a/modules/salt/pages/salt-command.adoc
+++ b/modules/salt/pages/salt-command.adoc
@@ -89,7 +89,7 @@ For more on targeting, see https://docs.saltstack.com/en/latest/topics/targeting
 
 == Salt Execution Modules
 
-When you have specified a target, provide the module to execute on the target.
+When you have specified a target, provide the module and function to execute on the target.
 
 Find which modules can be executed on the target:
 ----
@@ -100,9 +100,9 @@ For a full list of callable modules, see https://docs.saltstack.com/en/latest/re
 
 
 
-== Salt Modules Arguments
+== Salt Function Arguments
 
-Modules accept arguments for any extra data.
+Functions accept arguments for any extra data.
 
 For example, the [command]``pkg.install`` function requires an argument specifying which package to install:
 ----

--- a/modules/salt/pages/salt-command.adoc
+++ b/modules/salt/pages/salt-command.adoc
@@ -1,7 +1,7 @@
 [[salt.command]]
 = The Salt Command
 
-A Salt command have three main components: target, function, and arguments.
+Salt commands have three main components: target, function, and arguments.
 The calls are constructed in this format:
 ----
 salt 'target' <function> [arguments]

--- a/modules/salt/pages/salt-example-formula.adoc
+++ b/modules/salt/pages/salt-example-formula.adoc
@@ -1,5 +1,5 @@
 [[salt.formula.example]]
-= Install the Example Formula
+= Install the Salt Example Formula
 
 // This seems pretty pointless, and a bit out of date.Removed from nav. LKB 2019-08-20
 

--- a/modules/salt/pages/salt-intro.adoc
+++ b/modules/salt/pages/salt-intro.adoc
@@ -1,7 +1,7 @@
 [[salt-intro]]
 = Introduction
 
-Salt is a configuration management system used by {productname} to manage clients.
+Salt is a remote execution engine, configuration management and orchestration system used by {productname} to manage clients.
 
 In {productname}, the Salt master runs on the {productname} Server, allowing you to register and manage Salt clients.
 

--- a/modules/salt/pages/salt-states.adoc
+++ b/modules/salt/pages/salt-states.adoc
@@ -161,7 +161,7 @@ You can then use Group IDs to set conditional values, for example:
   pkg_download_point_protocol: http
   pkg_download_point_host: example.com
   pkg_download_point_port: 444
-{%else%}
+{% else %}
   pkg_download_point_protocol: ftp
   pkg_download_point_host: example.com
   pkg_download_point_port: 445
@@ -173,7 +173,7 @@ You can then use Group IDs to set conditional values, for example:
     pkg_download_point: example1.com
 {% elif grains['fqdn'] == 'client2.example.com'' %}
     pkg_download_point: example2.com
-{%else%}
+{% else %}
     pkg_download_point: example.com
 {% endif %}
 ----

--- a/modules/salt/pages/salt-useful-commands.adoc
+++ b/modules/salt/pages/salt-useful-commands.adoc
@@ -40,6 +40,12 @@ List public keys:
 salt-key -l
 ----
 
+salt-key -a my-minion::
+Accept pending key for a minion:
+----
+salt-key -a my-minion
+----
+
 salt-key -A::
 Accept all pending keys:
 ----

--- a/modules/salt/pages/salt-useful-commands.adoc
+++ b/modules/salt/pages/salt-useful-commands.adoc
@@ -1,4 +1,4 @@
-[[salt.useful_commands]]
+[[salt.useful-commands]]
 = Salt useful commands
 
 

--- a/modules/salt/pages/salt-useful-commands.adoc
+++ b/modules/salt/pages/salt-useful-commands.adoc
@@ -1,5 +1,5 @@
 [[salt.useful-commands]]
-= Salt useful commands
+= Salt Useful Commands
 
 
 This section contains the most used Salt commands.

--- a/modules/salt/pages/salt-useful-commands.adoc
+++ b/modules/salt/pages/salt-useful-commands.adoc
@@ -1,5 +1,5 @@
-[[salt.commands]]
-= Salt Commands
+[[salt.useful_commands]]
+= Salt useful commands
 
 
 This section contains the most used Salt commands.


### PR DESCRIPTION
This PR suggests some changes into the Salt guide after reviewing some of the Salt pages:

- Avoid using "Salt Calls" to prevent confusion with `salt-call` command line tool. This page has been renamed to "Salt Command"
- Rename "Salt Commands" to "Salt Useful Commands" to avoid duplicity.
- Minor adjustments on different pages

Tracker: https://github.com/SUSE/spacewalk/issues/9296
