### PR TITLE
Fix for grains typo

### DIFF
--- a/modules/salt/pages/salt-terminology.adoc
+++ b/modules/salt/pages/salt-terminology.adoc
@@ -39,7 +39,7 @@ List all available grains with the [command]``grains.ls`` function:
 salt '*' grains.ls
 ----
 
-You can also use [command]``grains.ls`` to list collected grain system data:
+You can also use [command]``grains.items`` to list collected grain system data:
 ----
 salt '*' grains.items
 ----


### PR DESCRIPTION
This should be `grains.items` instead of `grains.ls`.