### PR TITLE
Removal of broker section

### DIFF
--- a/modules/salt/pages/salt-terminology.adoc
+++ b/modules/salt/pages/salt-terminology.adoc
@@ -13,14 +13,6 @@ For {rhel} systems, install the [package]``python-inotify`` package.
 For more information on beacons, see https://docs.saltstack.com/en/latest/topics/beacons/
 
 
-Broker::
-The Salt broker allows clients to pass commands to each other.
-
-The Salt broker acts like a switch, therefore peer communication will only work for clients on the same network, or connected to the same proxy.
-
-For more information on Salt and peer communication, see https://docs.saltstack.com/en/latest/ref/peer.html.
-
-
 Environment::
 {productname} implements Salt with a single environment.
 Multiple Salt environments are not supported.


### PR DESCRIPTION
I've opened this as a draft, so that we have a place to discuss this change. The problem I have with the broker description is the following: We don't really use the term broker anywhere and the description is confusing. P2P communication is not really something we leverage. Instead of we should talk about salt proxies and that proxies are used to scale large systems, because we can take load from the master to the proxies. Does that sound right you you, @Loquacity? 