### PR TITLE
Update ssl-certs.adoc

### DIFF
--- a/modules/administration/pages/ssl-certs.adoc
+++ b/modules/administration/pages/ssl-certs.adoc
@@ -95,7 +95,7 @@ If your existing custom certificates have expired or stopped working for any rea
 rhn-ssl-tool --gen-server --dir="/root/ssl-build" --set-country="COUNTRY" \
 --set-state="STATE" --set-city="CITY" --set-org="ORGANIZATION" \
 --set-org-unit="ORGANIZATION UNIT" --set-email="name@example.com" \
---set-hostname="susemanager.example.top" --set-cname="example.com"
+--set-hostname="susemanager.example.com" --set-cname="example.com"
 ----
 Ensure that the [systemitem]``set-cname`` parameter is the fully-qualified domain name of your {productname} Server.
 You can use the the [systemitem]``set-cname`` parameter multiple times if you require multiple aliases.

--- a/modules/administration/pages/ssl-certs.adoc
+++ b/modules/administration/pages/ssl-certs.adoc
@@ -291,7 +291,7 @@ rhnpush -c ssl-ca-channel --nosig \
 
 
 When you have the new certificate in the channel, you can use the {productname} {webui} to update it on all clients and proxies, by synchronizing them with the channel.
-Alternatively, for Salt Clients, you can use menu:Salt[Remote Commands], or apply the highstate.
+Alternatively, for Salt clients, you can use menu:Salt[Remote Commands], or apply the highstate.
 
 
 You will also need to update your proxies to remove the copy of the certificate and the associated RPM.

--- a/modules/administration/pages/ssl-certs.adoc
+++ b/modules/administration/pages/ssl-certs.adoc
@@ -50,7 +50,7 @@ export SERVER_CERT=<path_to_web_server_certificate>
 . Complete {productname} setup:
 +
 ----
-yast2 susemanagersetup
+yast susemanager_setup
 ----
 +
 When you are prompted for certificate details during setup, fill in random values.
@@ -58,7 +58,7 @@ The values will be overridden by the values you specified at the command prompt.
 
 [NOTE]
 ====
-Execute the [command]``yast2 susemanagersetup`` command from the same shell you exported the environment variables from.
+Execute the [command]``yast susemanager_setup`` command from the same shell you exported the environment variables from.
 ====
 
 
@@ -114,6 +114,7 @@ spacewalk-service restart
 
 
 
+[[custom-ssl-create-replace-cert]]
 == Create and Replace CA and Server Certificates
 
 If you need to create entirely new certificates for an existing installation, you need to create a combined certificate first.

--- a/modules/administration/pages/ssl-certs.adoc
+++ b/modules/administration/pages/ssl-certs.adoc
@@ -291,7 +291,7 @@ rhnpush -c ssl-ca-channel --nosig \
 
 
 When you have the new certificate in the channel, you can use the {productname} {webui} to update it on all clients and proxies, by synchronizing them with the channel.
-Alternatively, for Salt clients, you can use menu:Salt[Remote Commands], or apply the highstate.
+Alternatively, for Salt Clients, you can use menu:Salt[Remote Commands], or apply the highstate.
 
 
 You will also need to update your proxies to remove the copy of the certificate and the associated RPM.


### PR DESCRIPTION
the wrong `susemanager_setup` spelling is creeping in again and again.
by default, we no longer want to enforce the graphical yast; use `yast` instead of `yast2`.
later on, we want to reference this label.