### PR TITLE
Most-recent Ubuntu first, like other OSs

### DIFF
--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -45,8 +45,8 @@ For details on supported product versions, see https://www.suse.com/lifecycle.
 //| CentOS 7 | {x86}, {x86}_64                            | icon:question[role="gray"]    | icon:question[role="gray"]
 //| CentOS 6 | {x86}, {x86}_64                            | icon:question[role="gray"]    | icon:question[role="gray"]
 | {opensuse} Leap 15.1 | {x86}_64                       | icon:times[role="danger"]      | icon:check[role="green"]
-| {ubuntu} 16.04 | {x86}_64                             | icon:times[role="danger"]      | icon:check[role="green"]
 | {ubuntu} 18.04 | {x86}_64                             | icon:times[role="danger"]      | icon:check[role="green"]
+| {ubuntu} 16.04 | {x86}_64                             | icon:times[role="danger"]      | icon:check[role="green"]
 |===
 
 


### PR DESCRIPTION
All the other OSs are listed from newer to older. Ubuntu was listed older to newer. This commit changes that to newer to older.