### PR TITLE
Rework retail environment setup and formulas pages

### DIFF
--- a/modules/retail/nav-retail.adoc
+++ b/modules/retail/nav-retail.adoc
@@ -11,6 +11,7 @@ ifndef::backend-pdf[]
 *** xref:retail-install-setup.adoc[Setting up]
 // Terminal ops
 ** xref:retail-deploy-terminals.adoc[Deploying Terminals]
+*** xref:retail-saltboot-diagram.adoc[Terminal Boot Process]
 *** xref:retail-terminal-names.adoc[Terminal Names]
 *** xref:retail-offline.adoc[Offline Use]
 *** xref:retail-terminal-ratelimiting.adoc[Rate Limiting Terminals]
@@ -58,7 +59,11 @@ include::modules/retail/pages/retail-network-arch.adoc[leveloffset=+3]
 
 include::modules/retail/pages/retail-install-setup.adoc[leveloffset=+3]
 
+// Terminal Ops
+
 include::modules/retail/pages/retail-deploy-terminals.adoc[leveloffset=+2]
+
+include::modules/retail/pages/retail-saltboot-diagram.adoc[leveloffset=+3]
 
 include::modules/retail/pages/retail-terminal-names.adoc[leveloffset=+3]
 

--- a/modules/retail/pages/retail-formulas-intro.adoc
+++ b/modules/retail/pages/retail-formulas-intro.adoc
@@ -17,13 +17,14 @@ Branch servers are configured using formulas. Formulas can be configured using {
 To fully configure {smr} environment, following formulas need to be enabled and configured for branch server:
 
 * Branch Network Formula, see xref:salt:formula-branchnetwork.adoc[]
-* Dhcpd Formula, see xref:salt:formula-bind.adoc[]
-* Bind Formula, see xref:salt:formula-dhcpd.adoc[]
+* Bind Formula, see xref:salt:formula-bind.adoc[]
+* Dhcpd Formula, see xref:salt:formula-dhcpd.adoc[]
 * PXE Formula, see xref:salt:formula-pxe.adoc[]
 * TFTP Formula, see xref:salt:formula-tftpd.adoc[]
 * Vsftp Formula, see xref:salt:formula-vsftpd.adoc[]
 
-Optionally [systemitem]``Image Synchronization Formula`` can be enabled and configured as well, see xref:salt:formula-imagesync.adoc[].
+Optionally, [systemitem]``Image Synchronization Formula`` can also be enabled and configured.
+For more information, see xref:salt:formula-imagesync.adoc[].
 
 [IMPORTANT]
 ====

--- a/modules/retail/pages/retail-formulas-intro.adoc
+++ b/modules/retail/pages/retail-formulas-intro.adoc
@@ -29,7 +29,7 @@ For more information, see xref:salt:formula-imagesync.adoc[].
 
 [IMPORTANT]
 ====
-It is very easy to misconfigure formulas that may result in branch not working properly.
+Badly configured formulas can result in the branch server failing to work as expected.
 Due to the generic nature of formulas it is difficult to do overall validation.
 We recommend that you configure the branch server using the {smr} command line utilities, and use individual formula settings for further tuning if required.
 For more information, see xref:retail:retail-install-setup.adoc[].

--- a/modules/retail/pages/retail-formulas-intro.adoc
+++ b/modules/retail/pages/retail-formulas-intro.adoc
@@ -7,22 +7,37 @@ Formulas are pre-written Salt states, that are used to configure your {smr} inst
 You can use the {productname} {webui} to apply common {productname} formulas.
 For the most commonly used formulas, see xref:salt:formulas-intro.adoc[].
 
-Alternatively, you can use pre-written formulas as a starting point for your own custom formulas.
-Pre-written formulas are available from https://github.com/saltstack-formulas.
-For more information on custom formulas, see xref:salt:formulas-custom.adoc[].
-
 All formulas must be accurately configured for your {smr} installation to function correctly.
 If you are unsure of the correct formula configuration details, run the [command]``retail_branch_init`` command before you begin to create the recommended formula configuration.
 You can then manually edit the formulas as required.
 
+== {smr} Branch Server Formulas
+
+Branch servers are configured using formulas. Formulas can be configured using {susemgr} {webui}, and {susemgr} XMLRPC API.
+To fully configure {smr} environment, following formulas need to be enabled and configured for branch server:
+
+* Branch Network Formula, see xref:salt:formula-branchnetwork.adoc[]
+* Dhcpd Formula, see xref:salt:formula-bind.adoc[]
+* Bind Formula, see xref:salt:formula-dhcpd.adoc[]
+* PXE Formula, see xref:salt:formula-pxe.adoc[]
+* TFTP Formula, see xref:salt:formula-tftpd.adoc[]
+* Vsftp Formula, see xref:salt:formula-vsftpd.adoc[]
+
+Optionally [systemitem]``Image Synchronization Formula`` can be enabled and configured as well, see xref:salt:formula-imagesync.adoc[].
+
+[IMPORTANT]
+====
+It is very easy to misconfigure formulas that may result in branch not working properly.
+Due to the generic nature of formulas it is difficult to do overall validation.
+When in doubt, configure branch server by {smr} provided command line utilities and then fine tune individual formulas, see xref:retail:retail-install-setup.adoc[].
+====
 
 .State and Formula Name Collisions
-[IMPORTANT]
+[WARNING]
 ====
 If a formula uses the same name as an existing Salt state, the two names will collide, and could result in the formula being used instead of the state.
 Always check the names of states and formulas to avoid name collisions.
 ====
 
-Most formulas can be updated using the {susemgr} {webui}.
 When you have made changes to your formula, ensure you apply the highstate.
 The highstate propagates your changes to the appropriate services.

--- a/modules/retail/pages/retail-formulas-intro.adoc
+++ b/modules/retail/pages/retail-formulas-intro.adoc
@@ -11,29 +11,30 @@ All formulas must be accurately configured for your {smr} installation to functi
 If you are unsure of the correct formula configuration details, run the [command]``retail_branch_init`` command before you begin to create the recommended formula configuration.
 You can then manually edit the formulas as required.
 
-== {smr} Branch Server Formulas
+== Branch Server Formulas
 
-Branch servers are configured using formulas. Formulas can be configured using {susemgr} {webui}, and {susemgr} XMLRPC API.
-To fully configure {smr} environment, following formulas need to be enabled and configured for branch server:
+Branch servers are configured using formulas. 
+Formulas can be configured using {susemgr} {webui}, or the {susemgr} XMLRPC API.
+To fully configure {smr}, these formulas need to be enabled and configured on the branch server:
 
-* Branch Network Formula, see xref:salt:formula-branchnetwork.adoc[]
-* Bind Formula, see xref:salt:formula-bind.adoc[]
-* Dhcpd Formula, see xref:salt:formula-dhcpd.adoc[]
-* PXE Formula, see xref:salt:formula-pxe.adoc[]
-* TFTP Formula, see xref:salt:formula-tftpd.adoc[]
-* Vsftp Formula, see xref:salt:formula-vsftpd.adoc[]
+* Branch network formula, see xref:salt:formula-branchnetwork.adoc[]
+* Bind formula, see xref:salt:formula-bind.adoc[]
+* DHCPD formula, see xref:salt:formula-dhcpd.adoc[]
+* PXE formula, see xref:salt:formula-pxe.adoc[]
+* TFTP formula, see xref:salt:formula-tftpd.adoc[]
+* VSFTP formula, see xref:salt:formula-vsftpd.adoc[]
 
-Optionally, [systemitem]``Image Synchronization Formula`` can also be enabled and configured.
+Optionally, you can also enable the image synchronization formula.
 For more information, see xref:salt:formula-imagesync.adoc[].
 
 [IMPORTANT]
 ====
 It is very easy to misconfigure formulas that may result in branch not working properly.
 Due to the generic nature of formulas it is difficult to do overall validation.
-When in doubt, configure branch server by {smr} provided command line utilities and then fine tune individual formulas, see xref:retail:retail-install-setup.adoc[].
+We recommend that you configure the branch server using the {smr} command line utilities, and use individual formula settings for further tuning if required.
+For more information, see xref:retail:retail-install-setup.adoc[].
 ====
 
-.State and Formula Name Collisions
 [WARNING]
 ====
 If a formula uses the same name as an existing Salt state, the two names will collide, and could result in the formula being used instead of the state.

--- a/modules/retail/pages/retail-install-setup.adoc
+++ b/modules/retail/pages/retail-install-setup.adoc
@@ -1,7 +1,7 @@
 [[retail-install-setup]]
 = Setting up
 
-This section requires installed and configured {susemgr} Server,at least one {smr} branch server and at least one {susemgr} build host.
+This section requires an installed and configured {susemgr} Server, one or more {smr} branch servers, and one or more {susemgr} build host.
 
 Next steps in configuring {smr} environment are:
 
@@ -13,7 +13,7 @@ These steps are usually performed multiple times in lifetime of {smr} and are lo
 
 Typically POS images are periodically rebuild when updated packages are available and then synchronized to the {smr} branch servers before update window.
 
-Configuration of {smr} branch server services has to be done each time new branch server is registered.
+Configuration of {smr} branch server services have to be done each time a new branch server is registered.
 
 == Prepare and Build Terminal Images
 
@@ -21,10 +21,10 @@ For information about {susemgr} image building, see xref:administration:image-ma
 
 {smr} POS images are images specifically tailored for {smr} environment and designed to be deployed using PXE booting mechanism.
 
-=== POS image templates
+=== POS Image Templates
 
 As starting point, {suse} provides basic templates at https://github.com/SUSE/manager-build-profiles/tree/master/OSImage[].
-These templates needs to be adapted for specific usecases, for example by including specific applications, configuration and users.
+These templates need to be adapted for specific usecases, for example by including specific applications, configuration settings, and users.
 
 [IMPORTANT]
 ====
@@ -58,7 +58,7 @@ For the information about the possible network topologies, see xref:retail:retai
 
 All configuration of branch server services is done on {susemgr} server.
 The configuration is then applied to the selected branch server through salt states.
-{susemgr} Formulas with Forms functionality is used to configure branch server services, however there are multiple ways to configure them.
+{susemgr} Formulas with Forms functionality is used to configure branch server services, however there are multiple ways to configure them:
 
 * {smr} provided command line tool [command]``retail_branch_init``
 * {smr} provided mass import command line tool [command]``retail_yaml``

--- a/modules/retail/pages/retail-install-setup.adoc
+++ b/modules/retail/pages/retail-install-setup.adoc
@@ -1,42 +1,69 @@
 [[retail-install-setup]]
 = Setting up
 
-When you have installed the [guimenu]``SUSE Manager for Retail Server`` and the [guimenu]``SUSE Manager Retail Branch Server``, you need to set up your environment by following these steps:
+This section requires installed and configured {susemgr} Server,at least one {smr} branch server and at least one {susemgr} build host.
 
-. Install the build host and register it to {susemgr}
-. Configure the build host
-. Create the required system group
+Next steps in configuring {smr} environment are:
 
-These are the branch server setup steps:
+. Prepare POS images
+. Configure {smr} branch server services
+. Synchronize POS images to {smr} branch servers
 
-// already done:
-// . Install the branch server and register it to {susemgr}
-. Assign and configure branch server formulas
-. Synchronize images to the branch servers
+These steps are usually performed multiple times in lifetime of {smr} and are loosely related.
 
-Each procedure is detailed in this section.
+Typically POS images are periodically rebuild when updated packages are available and then synchronized to the {smr} branch servers before update window.
 
+Configuration of {smr} branch server services has to be done each time new branch server is registered.
 
+== Prepare and Build Terminal Images
 
-== Create Required System Groups
+For information about {susemgr} image building, see xref:administration:image-management.adoc[].
 
-{smr} requires system groups for terminals and servers.
-Manually create these system groups during installation:
+{smr} POS images are images specifically tailored for {smr} environment and designed to be deployed using PXE booting mechanism.
 
-* [systemitem]``TERMINALS``
-* [systemitem]``SERVERS``
+=== POS image templates
 
-Additionally, you will need to create a system group for each branch server, and each terminal hardware type in your environment.
+As starting point, {suse} provides basic templates at https://github.com/SUSE/manager-build-profiles/tree/master/OSImage[].
+These templates needs to be adapted for specific usecases, for example by including specific applications, configuration and users.
 
-You can create system groups using the {susemgr} {webui}.
-Navigate to menu:Systems[System Groups] and click btn:[Create System Group].
+[IMPORTANT]
+====
+POS templates do not describe any system user. Using {suse} provided templates as is will result in system without possibility of user login. Salt management of the system is unaffected, however.
+====
 
-For more information about system groups, see xref:reference:systems/system-groups.adoc[].
+=== Terminals Based on SLES{nbsp}11 SP{nbsp}3
 
+POS Terminals based on {sles}{nbsp}11 SP{nbsp}3 can be deployed in much the same way as other terminals, with a few differences.
 
-== Assign and Configure Branch Server Formulas
+* You must use the SLES{nbsp}11 template
+* SLES{nbsp}11 images need to be activated with the [systemitem]``SLES11 SP3 i586`` and [systemitem]``SLEPOS 11 SP3 i586`` channels
 
-Before you configure the branch server, ensure you have decided on networking topology, and know the Salt ID of the branch server.
+[IMPORTANT]
+====
+Ensure that SLES{nbsp}11 images are built on the SLES{nbsp}11 build host.
+Building on the incorrect build host will cause your build to fail.
+====
+
+[WARNING]
+====
+If you are building images for SLES{nbsp}11 using profiles from an HTTPS git repository that uses TLS 1.0 or greater, it will fail.
+SLES{nbsp}11 does not support later versions of TLS.
+You will need to clone the repository locally in order to use it for building.
+====
+
+== Configure {smr} Branch Server services
+
+Before you configure the branch server, ensure you have decided on networking topology, and know the minion ID of the branch server.
+For the information about the possible network topologies, see xref:retail:retail-network-arch.adoc[].
+
+All configuration of branch server services is done on {susemgr} server.
+The configuration is then applied to the selected branch server through salt states.
+{susemgr} Formulas with Forms functionality is used to configure branch server services, however there are multiple ways to configure them.
+
+* {smr} provided command line tool [command]``retail_branch_init``
+* {smr} provided mass import command line tool [command]``retail_yaml``
+* {susemgr} web UI and configuring formulas manually (for advanced users)
+
 
 The branch server can be configured automatically using the [command]``retail_branch_init`` command, as shown in this section.
 If you prefer to manually configure the branch server, you can do so using formulas.
@@ -47,52 +74,113 @@ For more information about formulas, see xref:retail:retail-formulas-intro.adoc[
 . Branch server configuration is performed using the [command]``retail_branch_init`` command:
 +
 ----
-retail_branch_init <branch_server_salt_id>
+retail_branch_init <branch_server_minion_id>
 ----
 +
-This command will configure branch server formulas with recommended values.
+This command will configure branch server formulas with default values and for shared networking topology.
+For dedicated network topology run this command:
++
+----
+retail_branch_init <branch_server_minion_id> --dedicated-nic <network_device>
+----
++
+You can customize network information as well, together with custom [systemitem]``branch prefix``. For example:
++
+----
+retail_branch_init <branch_server_minion_id> --dedicated-nic eth1
+                                             --branch-prefix B001
+                                             --server-domain <branch_server_subdomain>
+                                             --branch-ip 192.168.86.1
+                                             --netmask 255.255.255.0
+----
++
 You can use the [command]``retail_branch_init --help`` command for additional options.
+
 . Verify that your changes have been configured correctly by checking the {susemgr} {webui} branch server system formulas.
 . Apply highstate on the branch server.
 You can do this through the {webui}, or by running this command:
 +
 ----
-salt <branch_server_salt_id> state.apply
+salt <branch_server_minion_id> state.apply
 ----
+
+Similar results can be achieved by using mass import command line tool.
+
+.Procedure: Configuring Branch Server Formulas With a Mass Import Tool
+
+. Prepare branch specific YAML file:
++
+For example, create branch.yaml file with content:
++
+----
+branches:
+  <branch_server_minion_id>:
+    branch_prefix: branch1
+    server_name: branchserver1
+    server_domain: example.com
+    nic: eth1
+    dedicated_nic: true
+    configure_firewall: true
+    branch_ip: 192.168.2.1
+    netmask: 255.255.255.0
+    dyn_range:
+        - 192.168.2.10
+        - 192.168.2.250
+----
++
+For more information about mass import tool, see xref:retail:retail-mass-config.adoc[].
+. Import branch information from YAML file to {susemgr}
++
+----
+retail_yaml --from-yaml branch.yaml
+----
+. Verify that your changes have been configured correctly by checking the {susemgr} {webui} branch server system formulas.
+. Apply highstate on the branch server.
+
+[WARNING]
+====
+Both [command]``retail_branch_init`` and [command]``retail_yaml`` commands overwrites existing configuration of specified branch server.
+====
+
+After the initial configuration done by command line tools, branch server configuration can be further adjusted in {susemgr} {webui} through branch server formulas.
+
+=== Create Required System Groups
+
+{smr} requires system groups for terminals and servers.
+Manually create these system groups during installation:
+
+* [systemitem]``TERMINALS``
+* [systemitem]``SERVERS``
+
+Additionally, you will need to create a system group for each branch server, and each terminal hardware type in your environment.
+For more information about hardware type groups, see xref:retail:retail-deploy-terminals.adoc[].
+
+Branch server groups are named after branch server prefixes, for example group name [systemitem]``B0001`` for branch server prefix [systemitem]``BOO1``.
+
+You can create system groups using the {susemgr} {webui}.
+Navigate to menu:Systems[System Groups] and click btn:[Create System Group].
+
+For more information about system groups, see xref:reference:systems/system-groups.adoc[].
+
+[NOTE]
+====
+{smr} command line tools create required system groups and branch group automatically.
+====
 
 
 == Synchronize Images to the Branch Server
 
-The OS image you use on the {susemgr} server must be synchronized for use on the branch server.
-You can do this with the Salt [command]``image-sync`` tool.
+The OS image you use on the {susemgr} server must be synchronized for use to the branch server.
+You can do this with the Salt [command]``image-sync`` state, part of the [systemitem]``Image Synchronization Formula``.
 
 .Procedure: Synchronizing Images to the Branch Server
 
 . On the {susemgr} server, run this command:
 +
 ----
-salt <branch_server_salt_id> state.apply image-sync
+salt <branch_server_minion_id> state.apply image-sync
 ----
 . The image details will be transferred to [path]``/srv/saltboot`` on the branch server.
 
-
-
-== Terminals Based on SLES{nbsp}11 SP{nbsp}3
-
-POS Terminals based on {sles}{nbsp}11 SP{nbsp}3 can be deployed in much the same way as other terminals, with a few differences.
-
-* You must use the SLES{nbsp}11 template
-* SLES{nbsp}11 images need to be activated with the [systemitem]``SLES11 SP3 i586`` and [systemitem]``SLEPOS 11 SP3 i586`` channels
-
-[IMPORTANT]
-====
-Ensure that SLES{nbsp}11 images are built on the SLES{nbsp}11 build host, and SLES{nbsp}12 images are built on the SLES{nbsp}12 build host.
-Building on the incorrect build host will cause your build to fail.
-====
-
-[WARNING]
-====
-If you are building images for SLES{nbsp}11 using profiles from an HTTPS git repository that uses TLS 1.0 or greater, it will fail.
-SLES{nbsp}11 does not support later versions of TLS.
-You will need to clone the repository locally in order to use it for building.
-====
+Synchronization can also be enabled to be done automatically on applying highstate on {smr} branch server using [systemitem]``Image Synchronization Formula``.
+For more information about [systemitem]``Image Synchronization Formula``, see xref:salt:formula-imagesync.adoc[].

--- a/modules/retail/pages/retail-install-setup.adoc
+++ b/modules/retail/pages/retail-install-setup.adoc
@@ -11,9 +11,9 @@ Next steps in configuring {smr} environment are:
 
 These steps are usually performed multiple times in lifetime of {smr} and are loosely related.
 
-Typically POS images are periodically rebuild when updated packages are available and then synchronized to the {smr} branch servers before update window.
+Usually, POS images are rebuild when updated packages are available, and synchronized to the branch servers before the update window opens.
 
-Configuration of {smr} branch server services have to be done each time a new branch server is registered.
+You will need to configure the services on the branch server every time a new branch server is registered.
 
 == Prepare and Build Terminal Images
 
@@ -31,7 +31,7 @@ These templates need to be adapted for specific usecases, for example by includi
 POS templates do not describe any system user. Using {suse} provided templates as is will result in system without possibility of user login. Salt management of the system is unaffected, however.
 ====
 
-=== Terminals Based on SLES{nbsp}11 SP{nbsp}3
+=== SLES{nbsp}11 SP{nbsp}3 Terminals
 
 POS Terminals based on {sles}{nbsp}11 SP{nbsp}3 can be deployed in much the same way as other terminals, with a few differences.
 
@@ -51,13 +51,13 @@ SLES{nbsp}11 does not support later versions of TLS.
 You will need to clone the repository locally in order to use it for building.
 ====
 
-== Configure {smr} Branch Server services
+== Configure Services on the Branch Server
 
 Before you configure the branch server, ensure you have decided on networking topology, and know the minion ID of the branch server.
 For the information about the possible network topologies, see xref:retail:retail-network-arch.adoc[].
 
-All configuration of branch server services is done on {susemgr} server.
-The configuration is then applied to the selected branch server through salt states.
+Configure branch server services from the {susemgr} Server.
+The configuration is then applied to the selected branch server using Salt states.
 {susemgr} Formulas with Forms functionality is used to configure branch server services, however there are multiple ways to configure them:
 
 * {smr} provided command line tool [command]``retail_branch_init``
@@ -182,5 +182,6 @@ salt <branch_server_minion_id> state.apply image-sync
 ----
 . The image details will be transferred to [path]``/srv/saltboot`` on the branch server.
 
-Synchronization can also be enabled to be done automatically on applying highstate on {smr} branch server using [systemitem]``Image Synchronization Formula``.
+You can also set synchronization to run automatically on the branch server.
+Configure the image synchronization formula to apply the highstate regularly.
 For more information about [systemitem]``Image Synchronization Formula``, see xref:salt:formula-imagesync.adoc[].

--- a/modules/retail/pages/retail-install-setup.adoc
+++ b/modules/retail/pages/retail-install-setup.adoc
@@ -28,7 +28,10 @@ These templates need to be adapted for specific usecases, for example by includi
 
 [IMPORTANT]
 ====
-POS templates do not describe any system user. Using {suse} provided templates as is will result in system without possibility of user login. Salt management of the system is unaffected, however.
+By default, POS templates do not include a system user. 
+You will not be able to login as a user to a system that has been installed with a {suse} provided template. 
+However you can use Salt to manage clients without a system user.
+You can use Salt to install a system user after the terminal has been deployed.
 ====
 
 === SLES{nbsp}11 SP{nbsp}3 Terminals

--- a/modules/retail/pages/retail-install-setup.adoc
+++ b/modules/retail/pages/retail-install-setup.adoc
@@ -1,19 +1,23 @@
 [[retail-install-setup]]
 = Setting up
 
-This section requires an installed and configured {susemgr} Server, one or more {smr} branch servers, and one or more {susemgr} build host.
+To set up an {smr} environment, you will need to have already installed and configured {susemgr} Server, have one or more {smr} branch server, and one or more {susemgr} build host.
 
-Next steps in configuring {smr} environment are:
+This section covers how to configure your {smr} environment, including:
+* Prepare POS images
+* Configure services on the branch server
+* Synchronize POS images to the branch servers
 
-. Prepare POS images
-. Configure {smr} branch server services
-. Synchronize POS images to {smr} branch servers
+The very first time you set up an {smr} environment, you will need to perform all three steps.
+You will need to revisit some of these steps later on as you are working with {smr}.
 
-These steps are usually performed multiple times in lifetime of {smr} and are loosely related.
+For example, the first time you configure the branch server, you will need to have images prepared for synchronization.
+If you are configuring more than one branch server, you can use the same images across different branch servers.
+
+If you have an existing environment, and need to build new images, you do not need to re-initialize the branches.
+You will need to synchronize the images, and can skip setting up the services on the branch server.
 
 Usually, POS images are rebuild when updated packages are available, and synchronized to the branch servers before the update window opens.
-
-You will need to configure the services on the branch server every time a new branch server is registered.
 
 == Prepare and Build Terminal Images
 
@@ -28,8 +32,8 @@ These templates need to be adapted for specific usecases, for example by includi
 
 [IMPORTANT]
 ====
-By default, POS templates do not include a system user. 
-You will not be able to login as a user to a system that has been installed with a {suse} provided template. 
+By default, POS templates do not include a system user.
+You will not be able to login as a user to a system that has been installed with a {suse} provided template.
 However you can use Salt to manage clients without a system user.
 You can use Salt to install a system user after the terminal has been deployed.
 ====
@@ -142,12 +146,12 @@ retail_yaml --from-yaml branch.yaml
 
 [WARNING]
 ====
-Both [command]``retail_branch_init`` and [command]``retail_yaml`` commands overwrites existing configuration of specified branch server.
+Both [command]``retail_branch_init`` and [command]``retail_yaml`` commands override existing configuration settings of the specified branch server.
 ====
 
 After the initial configuration done by command line tools, branch server configuration can be further adjusted in {susemgr} {webui} through branch server formulas.
 
-=== Create Required System Groups
+=== Required System Groups
 
 {smr} requires system groups for terminals and servers.
 Manually create these system groups during installation:

--- a/modules/retail/pages/retail-install-unified.adoc
+++ b/modules/retail/pages/retail-install-unified.adoc
@@ -41,7 +41,7 @@ yast susemanager_setup
 . Follow the prompts to set up your account.
 Ensure you take note of the passwords you set, you will need them later on.
 
-Continue with general {susemgr} configuration and channel synchronization at xref:installation:server-setup[].
+Continue with general {susemgr} configuration and channel synchronization at xref:installation:server-setup.adoc[].
 
 == Installing {smr} Branch Server
 
@@ -77,7 +77,7 @@ For more information about activation keys, see xref:client-configuration:client
 * SLE-Module-Server-Applications15-SP1-Pool for x86_64 SMRBS 4.0
 * SLE-Module-Server-Applications15-SP1-Updates for x86_64 SMRBS 4.0
 * SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates for x86_64
-. Use this activation key in {susemgrproxy} registration at xref:installation:proxy-registration[].
+. Use this activation key in {susemgrproxy} registration at xref:installation:proxy-registration.adoc[].
 
 
 [WARNING]


### PR DESCRIPTION
* Add new retail formulas content and rework retail setup
* Fix non-working links in retail install
  - two links in retail install were missing .adoc suffix
* Add saltboot diagram to the Terminal ops as a boot process

https://github.com/SUSE/spacewalk/issues/9297