### PR TITLE
No CentOS 7 i386

### DIFF
--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -42,7 +42,7 @@ For details on supported product versions, see https://www.suse.com/lifecycle.
 | {rhel} 7 | {x86}_64                                   | icon:check[role="green"]      | icon:check[role="green"]
 | {rhel} 6 | {x86}, {x86}_64                            | icon:check[role="green"]      | icon:check[role="green"]
 //| {centos} 8 | {x86}_64                                   | icon:times[role="danger"]    | icon:question[role="green"]
-| {centos} 7 | {x86}, {x86}_64                            | icon:question[role="gray"]/icon:check[role="green"] (with ES)   | icon:question[role="gray"] / icon:check[role="green"] (with ES)
+| {centos} 7 | {x86}_64                            | icon:question[role="gray"]/icon:check[role="green"] (with ES)   | icon:question[role="gray"] / icon:check[role="green"] (with ES)
 | {centos} 6 | {x86}, {x86}_64                            | icon:question[role="gray"]/icon:check[role="green"] (with ES)   | icon:question[role="gray"] / icon:check[role="green"] (with ES)
 | {ubuntu} 18.04 | {x86}_64                             | icon:times[role="danger"]      | icon:check[role="green"]
 | {ubuntu} 16.04 | {x86}_64                             | icon:times[role="danger"]      | icon:check[role="green"]


### PR DESCRIPTION
We don't support CentOS 7 x86. I probably introduced this mistake by copy & pasting.