### PR TITLE
Port 8050 no longer needs to be opened

### DIFF
--- a/modules/installation/pages/ports.adoc
+++ b/modules/installation/pages/ports.adoc
@@ -34,7 +34,6 @@ The client initiates the connection, and it stays open to receive commands from 
 The client initiates the connection, and it stays open to report results back to the Salt master.
 | 5222        | TCP      | osad    | Required to push OSAD actions to clients.
 | 5269        | TCP      | jabberd | Required to push actions to and from a proxy.
-| 8050        | TCP      | websockify | Required to access the graphical console of virtual machines with the {webui}.
 | 25151       | TCP      | Cobbler |
 |===
 
@@ -55,7 +54,6 @@ Port 80 is not used to serve the {webui}.
 | 80          | TCP | HTTP       | Required for {scc}.
 | 443         | TCP | HTTPS      | Required for {scc}.
 | 5269        | TCP | jabberd    | Required to push actions to and from a proxy.
-| 8050        | TCP | websockify | Required to access the graphical console of virtual machines with the {webui}.
 | 25151       | TCP | Cobbler    |
 |===
 


### PR DESCRIPTION
Since uyuni-project/uyuni#1579 and SUSE/spacewalk#10044 the client doesn't need access to port 8050 on the server.