### PR TITLE
rework live patching

### DIFF
--- a/modules/administration/nav-administration-guide.adoc
+++ b/modules/administration/nav-administration-guide.adoc
@@ -9,6 +9,7 @@ ifndef::backend-pdf[]
 *** xref:custom-channels.adoc[Custom Channels]
 // Live Patching
 ** xref:live-patching.adoc[Live Patching]
+*** xref:live-patching-channel-setup.adoc[Channel Setup for Live Patching]
 *** xref:live-patching-sles15.adoc[Live Patching on SLES 15]
 *** xref:live-patching-sles12.adoc[Live Patching on SLES 12]
 // Monitoring
@@ -83,6 +84,8 @@ include::modules/administration/pages/custom-channels.adoc[leveloffset=+2]
 
 // Live Patching
 include::modules/administration/pages/live-patching.adoc[leveloffset=+1]
+
+include::modules/administration/pages/live-patching-channel-setup.adoc[leveloffset=+2]
 
 include::modules/administration/pages/live-patching-sles15.adoc[leveloffset=+2]
 

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -1,5 +1,5 @@
 [[live-patching-channel-setup]]
-= Setup Channels for Live Patching
+= Set up Channels for Live Patching
 
 Every update of the full kernel package would require a reboot.
 Therefor it is important to not have newer kernels available in the channels assigned to clients which should use Live Patching.
@@ -73,4 +73,3 @@ In this procedure, you will also add the Live Patching child channels to your cl
 . Click btn:[Next], confirm that the details are correct, and click btn:[Confirm] to  save the changes.
 
 You can now select and view available CVE patches, and apply these important kernel updates with Live Patching.
-

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -1,0 +1,76 @@
+[[live-patching-channel-setup]]
+= Setup Channels for Live Patching
+
+Every update of the full kernel package would require a reboot.
+Therefor it is important to not have newer kernels available in the channels assigned to clients which should use Live Patching.
+
+For these clients only the Live Patching channel contains updates of the running kernel.
+
+There are two ways to manage channels for Live Patching:
+
+1. Use Content Lifecycle Management to clone the product tree and remove kernel versions newer than the running one. This procedure is explained in the xref:content-lifecycle-examples.adoc#enhance-project-with-livepatching[Content Livecycle Management Examples].
+This is the prefered solution.
+
+2. Use `spacewalk-manage-channel-lifecycle` tool. This procedure is more manual and requires commandline tools as well as the Web UI. This procedure is explained below for SLES 15 SP1, but it works similar for SLE12 SP4 or later as well.
+
+== Use spacewalk-manage-channel-lifecycle for Live Patching
+
+Cloned vendor channels should be prefixed by ``dev`` for development, ``testing``, or  ``prod`` for production.
+In this procedure, you will create a ``dev`` cloned channel, and later, you will need to promote the channel to ``testing``.
+
+.Procedure: Cloning Live Patching Channels
+
+. At the command prompt on the client, as `root`, obtain the current package channel tree:
++
+
+[subs=attributes]
+----
+# spacewalk-manage-channel-lifecycle --list-channels
+Spacewalk Username: admin
+Spacewalk Password:
+Channel tree:
+
+ 1. sles15-{sp-vert}-pool-x86_64
+      \__ sle-live-patching15-pool-x86_64-{sp-vert}
+      \__ sle-live-patching15-updates-x86_64-{sp-vert}
+      \__ sle-manager-tools15-pool-x86_64-{sp-vert}
+      \__ sle-manager-tools15-updates-x86_64-{sp-vert}
+      \__ sles15-{sp-vert}-updates-x86_64
+----
+
+. Use the [command]``spacewalk-manage-channel`` command with the [option]``init`` argument to automatically create a new development clone of the original vendor channel:
++
+[subs=attributes]
+----
+spacewalk-manage-channel-lifecycle --init -c sles15-{sp-vert}-pool-x86_64
+----
+[subs=attributes]
+. Check that [systemitem]``dev-sles15-{sp-vert}-updates-x86_64`` is available in your channel list.
+
+Check the ``dev`` cloned channel you created, and remove any kernel updates that require a reboot.
+
+.Procedure: Removing Non-Live Kernel Patches from Cloned Channels
+
+. Check the current kernel version by selecting the client from menu:Systems[System List], and taking note of the version displayed in the [guimenu]``Kernel`` field.
+. In the {productname} {webui}, select the client from menu:Systems[Overview], navigate to the menu:Software[Manage > Channels] tab, and select [systemitem]``dev-sles15-sp{sp-vert}-updates-x86_64``.
+Navigate to the [guimenu]``Patches`` tab, and click btn:[List/Remove Patches].
+. In the search bar, type [systemitem]``kernel`` and identify the kernel version that matches the kernel currently used by your client.
+. Remove all kernel versions that are newer than the currently installed kernel.
+
+Your channel is now set up for Live Patching, and can be promoted to ``testing``.
+In this procedure, you will also add the Live Patching child channels to your client, ready to be applied.
+
+.Procedure: Promoting Live Patching Channels
+
+. At the command prompt on the client, as `root`, promote and clone the `dev-sles15-{sp-vert}-pool-x86_64` channel to a new testing channel:
++
+[subs=attributes]
+----
+# spacewalk-manage-channel-lifecycle --promote -c dev-sles15-{sp-vert}-pool-x86_64
+----
+. In the {productname} {webui}, select the client from menu:Systems[Overview], and navigate to the menu:Software[Software Channels] tab.
+. Check the new [systemitem]``test-sles15-sp{sp-vert}-pool-x86_64`` custom channel to change the base channel, and check both corresponding Live Patching child channels.
+. Click btn:[Next], confirm that the details are correct, and click btn:[Confirm] to  save the changes.
+
+You can now select and view available CVE patches, and apply these important kernel updates with Live Patching.
+

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -18,7 +18,7 @@ This procedure is explained in this section for SLES{nbsp}15 SP1, but it also wo
 == Use spacewalk-manage-channel-lifecycle for Live Patching
 
 Cloned vendor channels should be prefixed by ``dev`` for development, ``testing``, or  ``prod`` for production.
-In this procedure, you will create a ``dev`` cloned channel, and later, you will need to promote the channel to ``testing``.
+In this procedure, you will create a ``dev`` cloned channel and then promote the channel to ``testing``.
 
 .Procedure: Cloning Live Patching Channels
 

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -1,7 +1,7 @@
 [[live-patching-channel-setup]]
 = Set up Channels for Live Patching
 
-Every update of the full kernel package would require a reboot.
+A reboot is required every time you update the full kernel package.
 Therefor it is important to not have newer kernels available in the channels assigned to clients which should use Live Patching.
 
 For these clients only the Live Patching channel contains updates of the running kernel.

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -11,7 +11,9 @@ There are two ways to manage channels for live patching:
 1. Use Content Lifecycle Management to clone the product tree and remove kernel versions newer than the running one. This procedure is explained in the xref:content-lifecycle-examples.adoc#enhance-project-with-livepatching[Content Livecycle Management Examples].
 This is the recommended solution.
 
-2. Use `spacewalk-manage-channel-lifecycle` tool. This procedure is more manual and requires commandline tools as well as the Web UI. This procedure is explained below for SLES 15 SP1, but it works similar for SLE12 SP4 or later as well.
+* Use the `spacewalk-manage-channel-lifecycle` tool. 
+This procedure is more manual and requires command line tools as well as the {webui}. 
+This procedure is explained in this section for SLES{nbsp}15 SP1, but it also works for SLE{nbsp}12 SP4 or later.
 
 == Use spacewalk-manage-channel-lifecycle for Live Patching
 

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -6,7 +6,7 @@ Therefore, it is important that clients using live patching do not have newer ke
 
 For these clients only the Live Patching channel contains updates of the running kernel.
 
-There are two ways to manage channels for Live Patching:
+There are two ways to manage channels for live patching:
 
 1. Use Content Lifecycle Management to clone the product tree and remove kernel versions newer than the running one. This procedure is explained in the xref:content-lifecycle-examples.adoc#enhance-project-with-livepatching[Content Livecycle Management Examples].
 This is the prefered solution.

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -4,7 +4,7 @@
 A reboot is required every time you update the full kernel package.
 Therefore, it is important that clients using live patching do not have newer kernels available in the channels they are assigned to.
 
-For these clients only the Live Patching channel contains updates of the running kernel.
+Clients using live patching have updates for the running kernel in the live patching channels.
 
 There are two ways to manage channels for live patching:
 

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -8,7 +8,8 @@ For these clients only the Live Patching channel contains updates of the running
 
 There are two ways to manage channels for live patching:
 
-1. Use Content Lifecycle Management to clone the product tree and remove kernel versions newer than the running one. This procedure is explained in the xref:content-lifecycle-examples.adoc#enhance-project-with-livepatching[Content Livecycle Management Examples].
+* Use Content Lifecycle Management to clone the product tree and remove kernel versions newer than the running one.
+This procedure is explained in the xref:content-lifecycle-examples.adoc#enhance-project-with-livepatching[Content Livecycle Management Examples].
 This is the recommended solution.
 
 * Use the `spacewalk-manage-channel-lifecycle` tool. 

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -9,7 +9,7 @@ For these clients only the Live Patching channel contains updates of the running
 There are two ways to manage channels for live patching:
 
 1. Use Content Lifecycle Management to clone the product tree and remove kernel versions newer than the running one. This procedure is explained in the xref:content-lifecycle-examples.adoc#enhance-project-with-livepatching[Content Livecycle Management Examples].
-This is the prefered solution.
+This is the recommended solution.
 
 2. Use `spacewalk-manage-channel-lifecycle` tool. This procedure is more manual and requires commandline tools as well as the Web UI. This procedure is explained below for SLES 15 SP1, but it works similar for SLE12 SP4 or later as well.
 

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -22,7 +22,7 @@ In this procedure, you will create a ``dev`` cloned channel and then promote the
 
 .Procedure: Cloning Live Patching Channels
 
-. At the command prompt on the client, as `root`, obtain the current package channel tree:
+. At the command prompt on the client, as root, obtain the current package channel tree:
 +
 
 [subs=attributes]

--- a/modules/administration/pages/live-patching-channel-setup.adoc
+++ b/modules/administration/pages/live-patching-channel-setup.adoc
@@ -2,7 +2,7 @@
 = Set up Channels for Live Patching
 
 A reboot is required every time you update the full kernel package.
-Therefor it is important to not have newer kernels available in the channels assigned to clients which should use Live Patching.
+Therefore, it is important that clients using live patching do not have newer kernels available in the channels they are assigned to.
 
 For these clients only the Live Patching channel contains updates of the running kernel.
 

--- a/modules/administration/pages/live-patching-sles12.adoc
+++ b/modules/administration/pages/live-patching-sles12.adoc
@@ -12,6 +12,8 @@ Before you begin, ensure:
 * Your SLES{nbsp}12 Salt clients are registered with {productname}
 * You have access to the SLES{nbsp}12 channels appropriate for your architecture, including the Live Patching child channel (or channels)
 * The clients are fully synchronized
+* Assign the clients to the cloned channels prepared for Live Patching (explained before)
+
 
 .Procedure: Setting up for Live Patching
 
@@ -23,63 +25,6 @@ image::enable_live_patching_kgraft_install.png[scaledwidth=80%]
 . Repeat for each client that you want to manage with Live Patching.
 . To check that Live Patching has been enabled correctly, select the client from menu:Systems[System List], and ensure that [systemitem]``Live Patching`` appears in the [guimenu]``Kernel`` field.
 
-
-When you have the Live Patching channel installed on the client, you can clone the default vendor channel.
-This cloned channel will be used to manage Live Patching on your clients.
-
-Cloned vendor channels should be prefixed by ``dev`` for development, ``testing``, or  ``prod`` for production.
-In this procedure, you will create a ``dev`` cloned channel, and later, you will need to promote the channel to ``testing``.
-
-
-.Procedure: Cloning Live Patching Channels
-
-. At the command prompt on the client, as `root`, obtain the current package channel tree:
-+
-----
-# spacewalk-manage-channel-lifecycle --list-channels
-Spacewalk Username: admin
-Spacewalk Password:
-Channel tree:
-
- 1. sles12-sp4-pool-x86_64
-      \__ sle-live-patching12-pool-x86_64-sp4
-      \__ sle-live-patching12-updates-x86_64-sp4
-      \__ sle-manager-tools12-pool-x86_64-sp4
-      \__ sle-manager-tools12-updates-x86_64-sp4
-      \__ sles12-sp4-updates-x86_64
-----
-. Use the [command]``spacewalk-manage-channel`` command with the [option]``init`` argument to automatically create a new development clone of the original vendor channel:
-+
-----
-spacewalk-manage-channel-lifecycle --init -c sles12-sp4-pool-x86_64
-----
-. Check that [systemitem]``dev-sles12-sp4-updates-x86_64`` is available in your channel list.
-
-Check the ``dev`` cloned channel you created, and remove any kernel updates that require a reboot.
-
-.Procedure: Removing Non-Live Kernel Patches from Cloned Channels
-
-. Check the current kernel version by selecting the client from menu:Systems[System List], and taking note of the version displayed in the [guimenu]``Kernel`` field.
-. In the {productname} {webui}, select the client from menu:Systems[Overview], navigate to the menu:Software[Manage > Channels] tab, and select [systemitem]``dev-sles12-sp4-updates-x86_64``.
-Navigate to the [guimenu]``Patches`` tab, and click btn:[List/Remove Patches].
-. In the search bar, type [systemitem]``kernel`` and identify the kernel version that matches the kernel currently used by your client.
-. Remove all kernel versions that are newer than the currently installed kernel.
-
-Your channel is now set up for Live Patching, and can be promoted to ``testing``.
-In this procedure, you will also add the Live Patching child channels to your client, ready to be applied.
-
-.Procedure: Promoting Live Patching Channels
-
-. At the command prompt on the client, as `root`, promote and clone the `dev-sles12-sp4-pool-x86_64` channel to a new testing channel:
-+
-----
-# spacewalk-manage-channel-lifecycle --promote -c dev-sles12-sp4-pool-x86_64
-----
-. In the {productname} {webui}, select the client from menu:Systems[Overview], and navigate to the menu:Software[Software Channels] tab.
-. Check the new [systemitem]``test-sles12-sp4-pool-x86_64`` custom channel to change the base channel, and check both corresponding Live Patching child channels.
-. Click btn:[Next], confirm that the details are correct, and click btn:[Confirm] to save the changes.
-
-You can now select and view available CVE patches, and apply these important kernel updates with Live Patching.
 
 .Procedure: Applying Live Patches to a Kernel
 

--- a/modules/administration/pages/live-patching-sles15.adoc
+++ b/modules/administration/pages/live-patching-sles15.adoc
@@ -10,6 +10,7 @@ Before you begin, ensure:
 * Your SLES{nbsp}15 Salt clients are registered with {productname}
 * You have access to the SLES{nbsp}15 channels appropriate for your architecture, including the Live Patching child channel (or channels)
 * The clients are fully synchronized
+* Assign the clients to the cloned channels prepared for Live Patching (explained before)
 
 .Procedure: Setting up for Live Patching
 
@@ -21,69 +22,6 @@ image::enable_live_patching_kernel_live_install.png[scaledwidth=80%]
 . Repeat for each client that you want to manage with Live Patching.
 . To check that Live Patching has been enabled correctly, select the client from menu:Systems[System List], and ensure that [systemitem]``Live Patch`` appears in the [guimenu]``Kernel`` field.
 
-
-When you have the Live Patching channel installed on the client, you can clone the default vendor channel.
-This cloned channel will be used to manage Live Patching on your clients.
-
-Cloned vendor channels should be prefixed by ``dev`` for development, ``testing``, or  ``prod`` for production.
-In this procedure, you will create a ``dev`` cloned channel, and later, you will need to promote the channel to ``testing``.
-
-
-.Procedure: Cloning Live Patching Channels
-
-. At the command prompt on the client, as `root`, obtain the current package channel tree:
-+
-
-[subs=attributes]
-----
-# spacewalk-manage-channel-lifecycle --list-channels
-Spacewalk Username: admin
-Spacewalk Password:
-Channel tree:
-
- 1. sles15-{sp-vert}-pool-x86_64
-      \__ sle-live-patching15-pool-x86_64-{sp-vert}
-      \__ sle-live-patching15-updates-x86_64-{sp-vert}
-      \__ sle-manager-tools15-pool-x86_64-{sp-vert}
-      \__ sle-manager-tools15-updates-x86_64-{sp-vert}
-      \__ sles15-{sp-vert}-updates-x86_64
-----
-
-. Use the [command]``spacewalk-manage-channel`` command with the [option]``init`` argument to automatically create a new development clone of the original vendor channel:
-+
-[subs=attributes]
-----
-spacewalk-manage-channel-lifecycle --init -c sles15-{sp-vert}-pool-x86_64
-----
-[subs=attributes]
-. Check that [systemitem]``dev-sles15-{sp-vert}-updates-x86_64`` is available in your channel list.
-
-Check the ``dev`` cloned channel you created, and remove any kernel updates that require a reboot.
-
-.Procedure: Removing Non-Live Kernel Patches from Cloned Channels
-
-. Check the current kernel version by selecting the client from menu:Systems[System List], and taking note of the version displayed in the [guimenu]``Kernel`` field.
-. In the {productname} {webui}, select the client from menu:Systems[Overview], navigate to the menu:Software[Manage > Channels] tab, and select [systemitem]``dev-sles15-sp{sp-vert}-updates-x86_64``.
-Navigate to the [guimenu]``Patches`` tab, and click btn:[List/Remove Patches].
-. In the search bar, type [systemitem]``kernel`` and identify the kernel version that matches the kernel currently used by your client.
-. Remove all kernel versions that are newer than the currently installed kernel.
-
-Your channel is now set up for Live Patching, and can be promoted to ``testing``.
-In this procedure, you will also add the Live Patching child channels to your client, ready to be applied.
-
-.Procedure: Promoting Live Patching Channels
-
-. At the command prompt on the client, as `root`, promote and clone the `dev-sles15-{sp-vert}-pool-x86_64` channel to a new testing channel:
-+
-[subs=attributes]
-----
-# spacewalk-manage-channel-lifecycle --promote -c dev-sles15-{sp-vert}-pool-x86_64
-----
-. In the {productname} {webui}, select the client from menu:Systems[Overview], and navigate to the menu:Software[Software Channels] tab.
-. Check the new [systemitem]``test-sles15-sp3-pool-x86_64`` custom channel to change the base channel, and check both corresponding Live Patching child channels.
-. Click btn:[Next], confirm that the details are correct, and click btn:[Confirm] to  save the changes.
-
-You can now select and view available CVE patches, and apply these important kernel updates with Live Patching.
 
 .Procedure: Applying Live Patches to a Kernel
 

--- a/modules/administration/pages/live-patching-sles15.adoc
+++ b/modules/administration/pages/live-patching-sles15.adoc
@@ -10,7 +10,7 @@ Before you begin, ensure:
 * Your SLES{nbsp}15 Salt clients are registered with {productname}
 * You have access to the SLES{nbsp}15 channels appropriate for your architecture, including the Live Patching child channel (or channels)
 * The clients are fully synchronized
-* Assign the clients to the cloned channels prepared for Live Patching (explained before)
+* Assign the clients to the cloned channels prepared for live patching
 
 .Procedure: Setting up for Live Patching
 


### PR DESCRIPTION
Split out spacewalk-manage-channel-lifecycle into an own Setup Chapter and change the order a bit.

The idea:

1st prepare the channels for Live Patching either with CLM (prefered) or with spacewalk-manage-channel-lifecycle tool.
2nd assign the clients to the clones and prepare the system for Live Patching.