### PR TITLE
Docs: update unsupported CaaSP operations

### DIFF
--- a/modules/client-configuration/pages/vhm-caasp.adoc
+++ b/modules/client-configuration/pages/vhm-caasp.adoc
@@ -31,16 +31,16 @@ For more information, see https://documentation.suse.com/suse-caasp/4/html/caasp
 
 [WARNING]
 ====
-Do not use Salt, {productname} (either via UI or API) to perform these actions on any {caasp} nodes:
+When using Salt or {productname} (either via UI or API) on any {caasp} nodes:
 
-* Apply a patch (if the patch is marked as interactive)
-* Mark a system to automatically install patches
-* Perform an SP migration
-* Reboot a node
-* Issue any power management action via Cobbler
-* Installing a package if it breaks or conflicts the `patterns-caasp-Node-x.y`
-* Removing a package if it breaks or conflicts or is one of the packages related with the `patterns-caasp-Node-x.y`
-* Upgrading a package if it breaks or conflicts or is one of the packages related with the `patterns-caasp-Node-x.y`
+* Do not apply a patch (if the patch is marked as interactive)
+* Do not mark a system to automatically install patches
+* Do not perform an SP migration
+* Do not reboot a node
+* Do not issue any power management action via Cobbler
+* Do not install a package if it breaks or conflicts the `patterns-caasp-Node-x.y`
+* Do not remove a package if it breaks or conflicts or is one of the packages related with the `patterns-caasp-Node-x.y`
+* Do not upgrade a package if it breaks or conflicts or is one of the packages related with the `patterns-caasp-Node-x.y`
 
 {productname} will not stop you from issuing these operations.
 Issuing those operation may render your {caasp} cluster unusable.

--- a/modules/client-configuration/pages/vhm-caasp.adoc
+++ b/modules/client-configuration/pages/vhm-caasp.adoc
@@ -26,18 +26,22 @@ When you have added the {caasp} nodes to {productname}, you will be able to:
 * Perform configuration management operations against the nodes, including using Salt states.
 * Assign different set of channels to clusters using channel staging and lifecycle management filters.
 
-Updates related to {k8s} are managed using the ``skuba`` tool.
+Updates related to {k8s} are managed using the ``skuba-update`` tool.
 For more information, see https://documentation.suse.com/suse-caasp/4/html/caasp-admin/_cluster_updates.html.
 
-////
-Waiting on clarification of this. LKB 2019-11-11
 [WARNING]
 ====
-Do not use {productname} to perform these actions on any {caasp} nodes:
+Do not use Salt, {productname} (either via UI or API) to perform these actions on any {caasp} nodes:
 
-* Install, upgrade, or removal of ``kubernetes-kubeadm``, ``kubernetes-kubelet``, ``kubernetes-client``, ``cri-o``, or ``cni-plugins``
-* Scheduling and executing a node reboot
+* Apply a patch (if the patch is marked as interactive)
+* Mark a system to automatically install patches
+* Perform an SP migration
+* Reboot a node
+* Issue any power management action via Cobbler
+* Installing a package if it breaks or conflicts the `patterns-caasp-Node-x.y`
+* Removing a package if it breaks or conflicts or is one of the packages related with the `patterns-caasp-Node-x.y`
+* Upgrading a package if it breaks or conflicts or is one of the packages related with the `patterns-caasp-Node-x.y`
 
-These actions are not supported.
+{productname} will not stop you from issuing these operations.
+Issuing those operation may render your {caasp} cluster unusable.
 ====
-////


### PR DESCRIPTION
As part of the merged RFC for forbidden CaaSP operations, this PR defines the operations that should not be done on a CaaSP node registered to Uyuni/SUSE Manager.
Ref: https://github.com/uyuni-project/uyuni-rfc/pull/26